### PR TITLE
Remove downvote feature

### DIFF
--- a/components/Comment.tsx
+++ b/components/Comment.tsx
@@ -18,12 +18,9 @@ export default function Comment({ comment }: ICommentProps) {
           </button>
           <div className="flex justify-center w-full">
             <div className="flex flex-row justify-center min-w-[26px] px-2 py-1 text-blue-900 bg-blue-400 bg-opacity-20 rounded-full">
-              <div className="overflow-hidden text-xs">{comment.netVoteCount}</div>
+              <div className="overflow-hidden text-xs">{comment.upvoteCount}</div>
             </div>
           </div>
-          <button type="button" className={`${comment.viewerHasDownvoted ? 'text-blue-600' : ''}`}>
-            <ArrowDownIcon className="transform hover:translate-y-[10%] transition-transform ease-in-out duration-150" />
-          </button>
         </div>
       </div>
       <div className="w-full min-w-0 border border-blue-400 rounded-md border-opacity-30">

--- a/lib/models/adapter.ts
+++ b/lib/models/adapter.ts
@@ -26,8 +26,7 @@ interface IBaseComment {
 export type IReply = IBaseComment;
 
 export interface IComment extends IBaseComment {
-  netVoteCount: number;
-  viewerHasDownvoted: boolean;
+  upvoteCount: number;
   viewerHasUpvoted: boolean;
   replyCount: number;
   replies: IReply[];

--- a/lib/models/github.ts
+++ b/lib/models/github.ts
@@ -29,8 +29,7 @@ interface GBaseComment {
 export type GReply = GBaseComment;
 
 export interface GComment extends GBaseComment {
-  netVoteCount: number;
-  viewerHasDownvoted: boolean;
+  upvoteCount: number;
   viewerHasUpvoted: boolean;
   replies: {
     totalCount: number;

--- a/services/github/getDiscussions.ts
+++ b/services/github/getDiscussions.ts
@@ -15,8 +15,7 @@ const GET_DISCUSSIONS_QUERY = `
         comments(first: 20) {
           totalCount
           nodes {
-            netVoteCount
-            viewerHasDownvoted
+            upvoteCount
             viewerHasUpvoted
             author {
               avatarUrl


### PR DESCRIPTION
Looks like GitHub silently removed it over the week.

## Before

![image](https://user-images.githubusercontent.com/6379424/113295045-e3346e00-9321-11eb-8485-dbb63843483e.png)

## After

![image](https://user-images.githubusercontent.com/6379424/113295063-e891b880-9321-11eb-9253-b5a48c8bf6c6.png)
