### PR TITLE
Reuse SWR for discussions

### DIFF
--- a/components/Giscussions.tsx
+++ b/components/Giscussions.tsx
@@ -1,32 +1,25 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import { AuthContext } from '../lib/context';
-import { IGiscussion } from '../lib/models/adapter';
 import { IGiscussionsRequest } from '../lib/models/giscussions';
-import { getGiscussions } from '../services/giscussions/discussions';
+import { useDiscussions } from '../services/giscussions/discussions';
 import Comment from './Comment';
 import CommentBox from './CommentBox';
 
 export type IGiscussionsProps = IGiscussionsRequest;
 
 export default function Giscussions(props: IGiscussionsProps) {
-  const [data, setData] = useState<IGiscussion | null>(null);
   const { token } = useContext(AuthContext);
-
-  useEffect(() => {
-    const getData = async () => {
-      const data = await getGiscussions(props, token);
-      setData(data);
-    };
-    getData();
-  }, [props, token]);
+  const { data, isLoading, isError } = useDiscussions(props, token);
 
   return (
     <div className="w-full text-gray-800">
       <div className="flex flex-wrap items-center">
         <h4 className="flex-auto my-2 mr-2 font-semibold">
-          {data
-            ? `${data.totalCount} comment${data.totalCount !== 1 ? 's' : ''}`
-            : 'Loading comments...'}
+          {isLoading
+            ? 'Loading comments...'
+            : isError
+            ? 'An error occurred.'
+            : `${data.totalCount} comment${data.totalCount !== 1 ? 's' : ''}`}
         </h4>
       </div>
 

--- a/services/giscussions/discussions.ts
+++ b/services/giscussions/discussions.ts
@@ -1,12 +1,20 @@
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { fetcher } from '../../lib/fetcher';
 import { IGiscussion } from '../../lib/models/adapter';
 import { IGiscussionsRequest } from '../../lib/models/giscussions';
 
-export async function getGiscussions(params: IGiscussionsRequest, token?: string) {
+export function useDiscussions(params: IGiscussionsRequest, token?: string) {
   const urlParams = new URLSearchParams({ ...params });
-  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const headers = useMemo(() => {
+    const headers = token ? { Authorization: `Bearer ${token}` } : {};
+    return { headers };
+  }, [token]);
 
-  const data = await fetch(`/api/discussions?${urlParams}`, { headers }).then((response) =>
-    response.json(),
-  );
-  return data as IGiscussion;
+  const { data, error } = useSWR<IGiscussion>([`/api/discussions?${urlParams}`, headers], fetcher);
+  return {
+    data: data,
+    isLoading: !error && !data,
+    isError: !!error,
+  };
 }


### PR DESCRIPTION
We dropped SWR when playing around with the discussions API. By bringing it back, comments would be revalidated regularly, so new comments will show up without having to reload the page.

Using SWR for `getToken` and `renderMarkdown` doesn't seem to make sense because they don't need to be revalidated. I tried it and it results in unnecessary requests to the APIs.