### PR TITLE
Use id to fetch discussion data

### DIFF
--- a/components/Giscussions.tsx
+++ b/components/Giscussions.tsx
@@ -1,15 +1,16 @@
 import { useContext } from 'react';
 import { AuthContext } from '../lib/context';
-import { IGiscussionsRequest } from '../lib/models/giscussions';
 import { useDiscussions } from '../services/giscussions/discussions';
 import Comment from './Comment';
 import CommentBox from './CommentBox';
 
-export type IGiscussionsProps = IGiscussionsRequest;
+export interface IGiscussionsProps {
+  id: string;
+}
 
-export default function Giscussions(props: IGiscussionsProps) {
+export default function Giscussions({ id }: IGiscussionsProps) {
   const { token } = useContext(AuthContext);
-  const { data, isLoading, isError } = useDiscussions(props, token);
+  const { data, isLoading, isError } = useDiscussions(id, token);
 
   return (
     <div className="w-full text-gray-800">

--- a/lib/adapter.ts
+++ b/lib/adapter.ts
@@ -1,5 +1,5 @@
 import { IComment, IGiscussion, IReactionGroups } from './models/adapter';
-import { GComment, GReactionGroup, GRepository, GUser } from './models/github';
+import { GComment, GReactionGroup, GRepositoryDiscussion, GUser } from './models/github';
 
 function adaptReactionGroups(reactionGroups: GReactionGroup[]): IReactionGroups {
   return reactionGroups.reduce((acc, group) => {
@@ -30,12 +30,11 @@ function adaptComments(comments: GComment[]): IComment[] {
 
 export function adaptDiscussions({
   viewer,
-  repository,
+  discussion,
 }: {
   viewer: GUser;
-  repository: GRepository;
+  discussion: GRepositoryDiscussion;
 }): IGiscussion {
-  const { discussion } = repository;
   const { comments: commentsData } = discussion;
 
   const totalCount = commentsData.nodes.reduce(

--- a/lib/models/giscussions.ts
+++ b/lib/models/giscussions.ts
@@ -5,9 +5,3 @@ export interface ITokenRequest {
 export interface ITokenResponse {
   token: string;
 }
-
-export interface IGiscussionsRequest {
-  repositoryOwner: string;
-  repositoryName: string;
-  discussionNumber: string;
-}

--- a/lib/models/github.ts
+++ b/lib/models/github.ts
@@ -38,12 +38,9 @@ export interface GComment extends GBaseComment {
 }
 
 export interface GRepositoryDiscussion {
+  id: string;
   comments: {
     totalCount: number;
     nodes: GComment[];
   };
-}
-
-export interface GRepository {
-  discussion: GRepositoryDiscussion;
 }

--- a/pages/api/discussions.ts
+++ b/pages/api/discussions.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getDiscussions, GetDiscussionsParams } from '../../services/github/getDiscussions';
+import { getDiscussion } from '../../services/github/getDiscussion';
 import { adaptDiscussions } from '../../lib/adapter';
 import { IGiscussion } from '../../lib/models/adapter';
 
@@ -9,13 +9,9 @@ export default async (
 ) => {
   const token = req.headers.authorization?.split('Bearer ')[1];
 
-  const params: GetDiscussionsParams = {
-    repositoryOwner: req.query.repositoryOwner as string,
-    repositoryName: req.query.repositoryName as string,
-    discussionNumber: +req.query.discussionNumber,
-  };
+  const params = { id: req.query.id as string };
 
-  const { data } = await getDiscussions(params, token);
+  const { data } = await getDiscussion(params, token);
   const adapted = adaptDiscussions(data);
 
   res.status(200).json(adapted);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,11 +45,7 @@ export default function Home() {
 
       <main className="w-full max-w-3xl mx-auto my-4">
         <AuthContext.Provider value={{ token, origin }}>
-          <Giscussions
-            repositoryOwner="laymonage"
-            repositoryName="discussions-playground"
-            discussionNumber="4"
-          />
+          <Giscussions id="MDEwOkRpc2N1c3Npb24zMjc5Nzgx" />
         </AuthContext.Provider>
       </main>
     </>

--- a/services/giscussions/discussions.ts
+++ b/services/giscussions/discussions.ts
@@ -2,10 +2,9 @@ import { useMemo } from 'react';
 import useSWR from 'swr';
 import { fetcher } from '../../lib/fetcher';
 import { IGiscussion } from '../../lib/models/adapter';
-import { IGiscussionsRequest } from '../../lib/models/giscussions';
 
-export function useDiscussions(params: IGiscussionsRequest, token?: string) {
-  const urlParams = new URLSearchParams({ ...params });
+export function useDiscussions(id: string, token?: string) {
+  const urlParams = new URLSearchParams({ id });
   const headers = useMemo(() => {
     const headers = token ? { Authorization: `Bearer ${token}` } : {};
     return { headers };

--- a/services/github/getDiscussion.ts
+++ b/services/github/getDiscussion.ts
@@ -1,17 +1,18 @@
-import { GUser, GRepository } from '../../lib/models/github';
+import { GUser, GRepositoryDiscussion } from '../../lib/models/github';
 import { getReadAccessToken } from './getReadAccessToken';
 
 const GITHUB_API_URL = 'https://api.github.com/graphql';
 
-const GET_DISCUSSIONS_QUERY = `
-  query($repositoryOwner: String!, $repositoryName: String!, $discussionNumber: Int!) {
+const GET_DISCUSSION_QUERY = `
+  query($id: ID!) {
     viewer {
       avatarUrl
       login
       url
     }
-    repository(owner: $repositoryOwner, name: $repositoryName) {
-      discussion(number: $discussionNumber) {
+    discussion: node(id: $id) {
+      ... on Discussion {
+        id
         comments(first: 20) {
           totalCount
           nodes {
@@ -62,23 +63,21 @@ const GET_DISCUSSIONS_QUERY = `
     }
   }`;
 
-export interface GetDiscussionsParams {
-  repositoryOwner: string;
-  repositoryName: string;
-  discussionNumber: number;
+export interface GetDiscussionParams {
+  id: string;
 }
 
-export interface GetDiscussionsBody {
+export interface GetDiscussionBody {
   data: {
     viewer: GUser;
-    repository: GRepository;
+    discussion: GRepositoryDiscussion;
   };
 }
 
-export async function getDiscussions(
-  params: GetDiscussionsParams,
+export async function getDiscussion(
+  params: GetDiscussionParams,
   token?: string,
-): Promise<GetDiscussionsBody> {
+): Promise<GetDiscussionBody> {
   return fetch(GITHUB_API_URL, {
     method: 'POST',
     headers: {
@@ -87,7 +86,7 @@ export async function getDiscussions(
     },
 
     body: JSON.stringify({
-      query: GET_DISCUSSIONS_QUERY,
+      query: GET_DISCUSSION_QUERY,
       variables: params,
     }),
   }).then((r) => r.json());


### PR DESCRIPTION
We'll need `id` to post comments and replies. Thus, I think it's easier if we just use `id` to load the discussion. We'll also need to dynamically search for discussions based on the page's metadata. The search results will also have `id`s of the discussion, so I think we're okay with this approach.