### PR TITLE
Move repository to giscus organization

### DIFF
--- a/ADVANCED-USAGE.md
+++ b/ADVANCED-USAGE.md
@@ -81,7 +81,7 @@ For example, given the following `<script>` tag:
 
 ```html
 <script src="https://giscus.app/client.js"
-        data-repo="laymonage/giscus"
+        data-repo="giscus/giscus"
         ...
         data-theme="https://giscus.app/themes/custom_example.css"
         ...>
@@ -231,5 +231,5 @@ sendMessage({
 ```
 
 [giscus.json]: giscus.json
-[creating-new-themes]: https://github.com/laymonage/giscus/blob/main/CONTRIBUTING.md#creating-new-themes
+[creating-new-themes]: https://github.com/giscus/giscus/blob/main/CONTRIBUTING.md#creating-new-themes
 [giscus.ts]: lib/types/giscus.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,26 @@ writing, this is a rolling-release project without any meaningful versioning
 whatsoever. Tags/releases may be created for the sole purpose of documenting
 major updates to the project.
 
+## 2021-09-30
+
+### changed
+
+- Move repository to giscus organization
+  ([#180](https://github.com/giscus/giscus/pull/180)).
+
 ## 2021-09-24
 
 ### added
 
 - Add Vercel banner
-  ([#179](https://github.com/laymonage/giscus/pull/179)).
+  ([#179](https://github.com/giscus/giscus/pull/179)).
 
 ## 2021-09-19
 
 ### changed
 
 - Reduce memory usage limit to 192MB
-  ([#178](https://github.com/laymonage/giscus/pull/178)). \
+  ([#178](https://github.com/giscus/giscus/pull/178)). \
   **Note:** please consider donating, I've been hitting my free usage limit on
   Vercel 🙁
 
@@ -28,19 +35,19 @@ major updates to the project.
 ### fixed
 
 - Improve accessibility and Lighthouse score
-  ([#175](https://github.com/laymonage/giscus/pull/175)).
+  ([#175](https://github.com/giscus/giscus/pull/175)).
 - Fix transparent background
-  ([#176](https://github.com/laymonage/giscus/pull/176)).
+  ([#176](https://github.com/giscus/giscus/pull/176)).
 
 ### changed
 
 - Self-host iframeResizer
-  ([#172](https://github.com/laymonage/giscus/pull/172),
-  [#173](https://github.com/laymonage/giscus/pull/173)).
+  ([#172](https://github.com/giscus/giscus/pull/172),
+  [#173](https://github.com/giscus/giscus/pull/173)).
 - Upgrade SWR to 1.0
-  ([#174](https://github.com/laymonage/giscus/pull/174)).
+  ([#174](https://github.com/giscus/giscus/pull/174)).
 - Get app host from environment variable
-  ([#177](https://github.com/laymonage/giscus/pull/177)). \
+  ([#177](https://github.com/giscus/giscus/pull/177)). \
   **Note:** if you self-host giscus, you need to set the
   `NEXT_PUBLIC_GISCUS_APP_HOST` variable so that the domain correctly shows up
   in the configuration step.
@@ -50,286 +57,286 @@ major updates to the project.
 ### changed
 
 - Upgrade dependencies
-  ([#171](https://github.com/laymonage/giscus/pull/171)).
+  ([#171](https://github.com/giscus/giscus/pull/171)).
 
 ## 2021-08-30
 
 ### changed
 
 - Redirect to app return URL if access is denied by user
-  ([#167](https://github.com/laymonage/giscus/pull/167)).
+  ([#167](https://github.com/giscus/giscus/pull/167)).
 
 ## 2021-08-22
 
 ### changed
 
 - Update upvotes and reactions UI to match GitHub's new UI
-  ([#164](https://github.com/laymonage/giscus/pull/164)). \
+  ([#164](https://github.com/giscus/giscus/pull/164)). \
   **Note:** this might be a **BREAKING** change if you use a custom CSS.
 - Scale font size to 5% of viewport width on tiny screens
-  ([#164](https://github.com/laymonage/giscus/pull/164)).
+  ([#164](https://github.com/giscus/giscus/pull/164)).
 - Project configuration fixes
-  ([#164](https://github.com/laymonage/giscus/pull/164)).
+  ([#164](https://github.com/giscus/giscus/pull/164)).
 
 ## 2021-08-13
 
 ### changed
 
 - Upgrade Next.js to 11.1
-  ([#161](https://github.com/laymonage/giscus/pull/161)).
+  ([#161](https://github.com/giscus/giscus/pull/161)).
 - Use `next/script` to load scripts
-  ([#161](https://github.com/laymonage/giscus/pull/161)).
+  ([#161](https://github.com/giscus/giscus/pull/161)).
 
 ## 2021-08-07
 
 ### changed
 
 - Refactor markup and CSS to improve customizability
-  ([#158](https://github.com/laymonage/giscus/pull/158)). \
+  ([#158](https://github.com/giscus/giscus/pull/158)). \
   **Note:** this might be a **BREAKING** change if you use a custom CSS.
 - Use `Navigator.clipboard` API to copy to clipboard
-  ([#159](https://github.com/laymonage/giscus/pull/159)).
+  ([#159](https://github.com/giscus/giscus/pull/159)).
 - Use `stale-while-revalidate` for theme files
-  ([#159](https://github.com/laymonage/giscus/pull/159)).
+  ([#159](https://github.com/giscus/giscus/pull/159)).
 
 ## 2021-08-01
 
 ### added
 
 - Add link to giscus-component
-  ([#155](https://github.com/laymonage/giscus/pull/155)).
+  ([#155](https://github.com/giscus/giscus/pull/155)).
 
 ## 2021-07-31
 
 ### changed
 
 - Use strict-origin Referrer-Policy to avoid excessive header length
-  ([#154](https://github.com/laymonage/giscus/pull/154)).
+  ([#154](https://github.com/giscus/giscus/pull/154)).
 - Improve theme performance on initial load to prevent flashing
-  ([#155](https://github.com/laymonage/giscus/pull/155)).
+  ([#155](https://github.com/giscus/giscus/pull/155)).
 
 ## 2021-07-25
 
 ### added
 
-- Add security headers ([#147](https://github.com/laymonage/giscus/pull/147)).
+- Add security headers ([#147](https://github.com/giscus/giscus/pull/147)).
 
 ### changed
 
 - Use media query in CSS for `preferred_color_scheme` theme
-  ([#146](https://github.com/laymonage/giscus/pull/146)).
+  ([#146](https://github.com/giscus/giscus/pull/146)).
 - The "origin not allowed" error message implemented in
-  [#125](https://github.com/laymonage/giscus/pull/125) is no longer shown.
+  [#125](https://github.com/giscus/giscus/pull/125) is no longer shown.
   Instead, the browser will now refuse to load the `iframe` as a result of
   the `frame-ancestors` value in the `Content-Security-Policy` header
-  ([#147](https://github.com/laymonage/giscus/pull/147)).
+  ([#147](https://github.com/giscus/giscus/pull/147)).
 - Upgrade Next.js to 11 and update other dependencies
-  ([#149](https://github.com/laymonage/giscus/pull/149)).
+  ([#149](https://github.com/giscus/giscus/pull/149)).
 - Only apply `iFrameResize` to `.giscus-frame` iframes
-  ([#150](https://github.com/laymonage/giscus/pull/150)).
+  ([#150](https://github.com/giscus/giscus/pull/150)).
 
 ### fixed
 
 - Fix unreadable reactions popup menu due to transparent background in
   Transparent Dark theme
-  ([#148](https://github.com/laymonage/giscus/pull/148)).
+  ([#148](https://github.com/giscus/giscus/pull/148)).
 
 ## 2021-07-12
 
 ### added
 
 - Link to GitHub guides for the repository requirements
-  ([#142](https://github.com/laymonage/giscus/pull/142)).
+  ([#142](https://github.com/giscus/giscus/pull/142)).
 
 ## 2021-07-11
 
 ### added
 
-- This changelog ([#139](https://github.com/laymonage/giscus/pull/139)).
+- This changelog ([#139](https://github.com/giscus/giscus/pull/139)).
 - Add option to emit discussion metadata
-  ([#136](https://github.com/laymonage/giscus/pull/136)).
+  ([#136](https://github.com/giscus/giscus/pull/136)).
 - Add support for updating config on-the-fly with `postMessage`
-  ([#138](https://github.com/laymonage/giscus/pull/138)).
+  ([#138](https://github.com/giscus/giscus/pull/138)).
 
 ### fixed
 
-- Minor fixes ([#137](https://github.com/laymonage/giscus/pull/137)).
+- Minor fixes ([#137](https://github.com/giscus/giscus/pull/137)).
 - Fix unchanged theme on initial load
-  ([#140](https://github.com/laymonage/giscus/pull/140)).
+  ([#140](https://github.com/giscus/giscus/pull/140)).
 - Fix `sendMessage` example
-  ([#141](https://github.com/laymonage/giscus/pull/141)).
+  ([#141](https://github.com/giscus/giscus/pull/141)).
 
 ## 2021-07-10
 
 ### fixed
 
 - Improve theme performance
-  ([#135](https://github.com/laymonage/giscus/pull/135)).
+  ([#135](https://github.com/giscus/giscus/pull/135)).
 
 ## 2021-07-09
 
 ### fixed
 
 - Fix memory limit config
-  ([#133](https://github.com/laymonage/giscus/pull/133)).
+  ([#133](https://github.com/giscus/giscus/pull/133)).
 
 ## 2021-07-08
 
 ### changed
 
 - Limit functions memory usage to 256MB
-  ([#132](https://github.com/laymonage/giscus/pull/132)).
+  ([#132](https://github.com/giscus/giscus/pull/132)).
 
 ## 2021-07-05
 
 ### added
 
 - Add custom CSS support
-  ([#128](https://github.com/laymonage/giscus/pull/128)).
+  ([#128](https://github.com/giscus/giscus/pull/128)).
 
 ## 2021-07-04
 
 ### added
 
 - Implement origin checking
-  ([#125](https://github.com/laymonage/giscus/pull/125)).
+  ([#125](https://github.com/giscus/giscus/pull/125)).
 - Update GitHub themes and add GitHub Dark High Contrast
-  ([#126](https://github.com/laymonage/giscus/pull/126)).
+  ([#126](https://github.com/giscus/giscus/pull/126)).
 
 ### fixed
 
 - Fix `getFile` service function
-  ([#127](https://github.com/laymonage/giscus/pull/127)).
+  ([#127](https://github.com/giscus/giscus/pull/127)).
 
 ## 2021-07-03
 
 ### fixed
 
 - Fix crash on categories with GitHub custom emojis
-  ([#122](https://github.com/laymonage/giscus/pull/122)).
+  ([#122](https://github.com/giscus/giscus/pull/122)).
 - Listen to preferred theme changes
-  ([#123](https://github.com/laymonage/giscus/pull/123)).
+  ([#123](https://github.com/giscus/giscus/pull/123)).
 - Force repository name to lowercase in discussion query
-  ([#124](https://github.com/laymonage/giscus/pull/124)).
+  ([#124](https://github.com/giscus/giscus/pull/124)).
 
 ## 2021-06-13
 
 ### added
 
 - Add Transparent Dark theme
-  ([#110](https://github.com/laymonage/giscus/pull/110)).
+  ([#110](https://github.com/giscus/giscus/pull/110)).
 
 ### changed
 
-- Minor improvements ([#111](https://github.com/laymonage/giscus/pull/111)).
+- Minor improvements ([#111](https://github.com/giscus/giscus/pull/111)).
 
 ## 2021-06-12
 
 ### fixed
 
 - Remove typo from privacy policy
-  ([#109](https://github.com/laymonage/giscus/pull/109)).
+  ([#109](https://github.com/giscus/giscus/pull/109)).
 
 ## 2021-06-06
 
 ### added
 
 - Add option to also filter by category
-  ([#105](https://github.com/laymonage/giscus/pull/105)).
+  ([#105](https://github.com/giscus/giscus/pull/105)).
 
 ## 2021-06-05
 
 ### fixed
 
 - Fix prerender crash if `getAppAccessToken` fails
-  ([#103](https://github.com/laymonage/giscus/pull/103)).
+  ([#103](https://github.com/giscus/giscus/pull/103)).
 
 ## 2021-06-04
 
 ### added
 
 - Add default CSS in client script
-  ([#102](https://github.com/laymonage/giscus/pull/102)).
+  ([#102](https://github.com/giscus/giscus/pull/102)).
 
 ### changed
 
 - Drop passthru GraphQL API
-  ([#99)](https://github.com/laymonage/giscus/pull/)).
+  ([#99)](https://github.com/giscus/giscus/pull/)).
 
 ### fixed
 
 - Fix missing space in "Sign in to"
-  ([#101](https://github.com/laymonage/giscus/pull/101)).
+  ([#101](https://github.com/giscus/giscus/pull/101)).
 
 ## 2021-06-02
 
 ### added
 
 - Create self-hosting guide
-  ([#98](https://github.com/laymonage/giscus/pull/98)).
+  ([#98](https://github.com/giscus/giscus/pull/98)).
 
 ### changed
 
-- Reduce bundle size ([#97](https://github.com/laymonage/giscus/pull/97)).
+- Reduce bundle size ([#97](https://github.com/giscus/giscus/pull/97)).
 
 ## 2021-06-01
 
 ### added
 
 - Implement reactions to discussions
-  ([#93](https://github.com/laymonage/giscus/pull/93)).
-- Add migrating guide ([#94](https://github.com/laymonage/giscus/pull/94)).
+  ([#93](https://github.com/giscus/giscus/pull/93)).
+- Add migrating guide ([#94](https://github.com/giscus/giscus/pull/94)).
 
 ### fixed
 
 - Handle bad credentials, invalid state, and log other errors
-  ([#95](https://github.com/laymonage/giscus/pull/95)).
+  ([#95](https://github.com/giscus/giscus/pull/95)).
 
 ## 2021-05-30
 
 ### fixed
 
 - Only listen to resize events from the iframe
-  ([#89](https://github.com/laymonage/giscus/pull/89)).
+  ([#89](https://github.com/giscus/giscus/pull/89)).
 
 ## 2021-05-29
 
 ### fixed
 
 - Opt-out of FLoC and fix some minor issues
-  ([#88](https://github.com/laymonage/giscus/pull/88)).
+  ([#88](https://github.com/giscus/giscus/pull/88)).
 
 
 ## 2021-05-27
 
 ### fixed
 
-- Minor improvements ([#83](https://github.com/laymonage/giscus/pull/83)).
+- Minor improvements ([#83](https://github.com/giscus/giscus/pull/83)).
 
 ## 2021-05-26
 
 ### changed
 
 - Branding-related updates
-  ([#82](https://github.com/laymonage/giscus/pull/82)).
+  ([#82](https://github.com/giscus/giscus/pull/82)).
 
 ## 2021-05-23
 
 ### fixed
 
 - Don't add clipboard button to `js-file-line-container`
-  ([#81](https://github.com/laymonage/giscus/pull/81)).
+  ([#81](https://github.com/giscus/giscus/pull/81)).
 
 ## 2021-05-22
 
 ### added
 
 - Reintroduce copy to clipboard button in code blocks
-  ([#78](https://github.com/laymonage/giscus/pull/78)).
+  ([#78](https://github.com/giscus/giscus/pull/78)).
 
 ### fixed
 
-- Minor improvements ([#79](https://github.com/laymonage/giscus/pull/79)).
+- Minor improvements ([#79](https://github.com/giscus/giscus/pull/79)).
 
 ## 2021-05-15
 
@@ -337,13 +344,13 @@ major updates to the project.
 
 - Initial release.
 - Link to discussions in comments count
-  ([#74](https://github.com/laymonage/giscus/pull/74)).
+  ([#74](https://github.com/giscus/giscus/pull/74)).
 
 ### fixed
 
 - Include forks in search queries
-  ([#71](https://github.com/laymonage/giscus/pull/71)).
+  ([#71](https://github.com/giscus/giscus/pull/71)).
 - Remove `fork:true` in discussion query
-  ([#73](https://github.com/laymonage/giscus/pull/73)).
+  ([#73](https://github.com/giscus/giscus/pull/73)).
 
 [keep-a-changelog]: https://keepachangelog.com/en/1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,6 @@ use it easily.
 [syntax-dark]: https://github.com/primer/github-syntax-dark
 [syntax-light]: https://github.com/primer/github-syntax-light
 [preferred-color-scheme]: styles/themes/preferred_color_scheme.css
-[gsc-classes]: https://github.com/laymonage/giscus/search?l=TSX&q=gsc
-[custom-theme-url]: https://github.com/laymonage/giscus/blob/main/ADVANCED-USAGE.md#data-theme
+[gsc-classes]: https://github.com/giscus/giscus/search?l=TSX&q=gsc
+[custom-theme-url]: https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#data-theme
 [variables]: lib/variables.ts

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ To comment, visitors must authorize the [giscus app][giscus-app] to [post on the
 [giscus]: https://giscus.app
 [discussions]: https://docs.github.com/en/discussions
 [utterances]: https://github.com/utterance/utterances
-[repo]: https://github.com/laymonage/giscus
-[advanced-usage]: https://github.com/laymonage/giscus/blob/main/ADVANCED-USAGE.md
-[creating-custom-themes]: https://github.com/laymonage/giscus/blob/main/ADVANCED-USAGE.md#data-theme
-[self-hosting]: https://github.com/laymonage/giscus/blob/main/SELF-HOSTING.md
+[repo]: https://github.com/giscus/giscus
+[advanced-usage]: https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md
+[creating-custom-themes]: https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#data-theme
+[self-hosting]: https://github.com/giscus/giscus/blob/main/SELF-HOSTING.md
 [search-api]: https://docs.github.com/en/graphql/guides/using-the-graphql-api-for-discussions#search
 [giscus-app]: https://github.com/apps/giscus
 [authorization]: https://docs.github.com/en/developers/apps/identifying-and-authorizing-users-for-github-apps
@@ -57,10 +57,10 @@ If you've previously used other systems that utilize GitHub Issues (e.g. [uttera
 See [CONTRIBUTING.md][contributing]
 
 [giscus-component]: https://github.com/giscus/giscus-component
-[repo]: https://github.com/laymonage/giscus
+[repo]: https://github.com/giscus/giscus
 [giscus-topic]: https://github.com/topics/giscus
 [topic-howto]: https://docs.github.com/en/github/administering-a-repository/classifying-your-repository-with-topics
-[advanced-usage]: https://github.com/laymonage/giscus/blob/main/ADVANCED-USAGE.md
+[advanced-usage]: https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md
 [utterances]: https://github.com/utterance/utterances
 [gitalk]: https://github.com/gitalk/gitalk
 [convert]: https://docs.github.com/en/discussions/managing-discussions-for-your-community/moderating-discussions#converting-an-issue-to-a-discussion
@@ -68,7 +68,7 @@ See [CONTRIBUTING.md][contributing]
 [os-phil-opp]: https://os.phil-opp.com
 [statsandr]: https://statsandr.com
 [techdebtburndown]: https://techdebtburndown.com
-[contributing]: https://github.com/laymonage/giscus/blob/main/CONTRIBUTING.md
+[contributing]: https://github.com/giscus/giscus/blob/main/CONTRIBUTING.md
 
 <!-- end -->
 

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -236,13 +236,13 @@ encounter any problems, [create a new issue][new-issue].
 [app-doc]: https://docs.github.com/apps/building-integrations
 [create-app]: https://github.com/settings/apps/new
 [giscus]: https://giscus.app
-[token-validity-period]: https://github.com/laymonage/giscus/blob/main/pages/api/oauth/authorized.ts#L6
+[token-validity-period]: https://github.com/giscus/giscus/blob/main/pages/api/oauth/authorized.ts#L6
 [vercel]: https://vercel.com
 [env-example]: .env.example
 [api-routes]: pages/api
 [services]: services
 [cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 [next-export]: https://nextjs.org/docs/advanced-features/static-html-export
-[configuration]: https://github.com/laymonage/giscus/blob/main/components/Configuration.tsx#L320
-[discussion]: https://github.com/laymonage/giscus/discussions/categories/q-a
-[new-issue]: https://github.com/laymonage/giscus/issues/new
+[configuration]: https://github.com/giscus/giscus/blob/main/components/Configuration.tsx#L320
+[discussion]: https://github.com/giscus/giscus/discussions/categories/q-a
+[new-issue]: https://github.com/giscus/giscus/issues/new

--- a/client.ts
+++ b/client.ts
@@ -123,7 +123,7 @@ if (!existingContainer) {
   while (existingContainer.firstChild) existingContainer.firstChild.remove();
   existingContainer.appendChild(iframeElement);
 }
-const suggestion = `Please consider reporting this error at https://github.com/laymonage/giscus/issues/new.`;
+const suggestion = `Please consider reporting this error at https://github.com/giscus/giscus/issues/new.`;
 
 // Listen to error messages
 window.addEventListener('message', (event) => {

--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -397,7 +397,7 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
           Discussion metadata will be sent periodically to the parent window. For demonstration,
           enable this option and open your {`browser's`} console on this page. See{' '}
           <a
-            href="https://github.com/laymonage/giscus/blob/main/ADVANCED-USAGE.md#imetadatamessage"
+            href="https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#imetadatamessage"
             target="_blank"
             rel="noreferrer noopener nofollow"
           >
@@ -411,7 +411,7 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
       <p>
         Choose a theme that matches your website. {`Can't`} find one that does?{' '}
         <a
-          href="https://github.com/laymonage/giscus/blob/main/CONTRIBUTING.md#creating-new-themes"
+          href="https://github.com/giscus/giscus/blob/main/CONTRIBUTING.md#creating-new-themes"
           target="_blank"
           rel="noreferrer noopener nofollow"
         >

--- a/giscus.json
+++ b/giscus.json
@@ -4,7 +4,7 @@
     "https://giscus.vercel.app"
   ],
   "originsRegex": [
-    "https:\/\/giscus-git-([A-z0-9]|-)*laymonage\\.vercel\\.app",
-    "http:\/\/localhost:[0-9]+"
+    "https://giscus-git-([A-z0-9]|-)*giscus\\.vercel\\.app",
+    "http://localhost:[0-9]+"
   ]
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,7 +15,7 @@ const meta = {
   title: 'giscus',
   description: 'A comments widget built on GitHub Discussions.',
   image:
-    'https://opengraph.githubassets.com/5500584364ff6fde70d120e51f28f33ffe97d8f4661517bba2ab9515d0765857/laymonage/giscus',
+    'https://opengraph.githubassets.com/4f866d5b634e7cd5422af77f8dbfb6d48dd288b7c5c18326544c1973210320ed/giscus/giscus',
 };
 
 export default function App({ Component, pageProps }: AppProps) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,9 +22,9 @@ export const getStaticProps = async () => {
   const [afterConfig] = contents[1].split('<!-- end -->');
   contents[1] = `${afterConfig}\n## try it out 👇👇👇\n`;
 
-  const token = await getAppAccessToken('laymonage/giscus').catch(() => '');
+  const token = await getAppAccessToken('giscus/giscus').catch(() => '');
   const [contentBefore, contentAfter] = await Promise.all(
-    contents.map(async (section) => await renderMarkdown(section, token, 'laymonage/giscus')),
+    contents.map(async (section) => await renderMarkdown(section, token, 'giscus/giscus')),
   );
 
   return {
@@ -93,7 +93,7 @@ export default function Home({ contentBefore, contentAfter }: HomeProps) {
     replies: [],
     replyCount: 0,
     upvoteCount: 0,
-    url: 'https://github.com/laymonage/giscus',
+    url: 'https://github.com/giscus/giscus',
     viewerDidAuthor: false,
     viewerHasUpvoted: false,
     viewerCanUpvote: false,
@@ -115,7 +115,7 @@ export default function Home({ contentBefore, contentAfter }: HomeProps) {
         <div className="w-full my-8 giscus" />
         <Script
           src="/client.js"
-          data-repo="laymonage/giscus"
+          data-repo="giscus/giscus"
           data-repo-id="MDEwOlJlcG9zaXRvcnkzNTE5NTgwNTM="
           data-category-id="MDE4OkRpc2N1c3Npb25DYXRlZ29yeTMyNzk2NTc1"
           data-mapping="specific"

--- a/services/github/getDiscussion.ts
+++ b/services/github/getDiscussion.ts
@@ -145,7 +145,7 @@ export async function getDiscussion(
   const { repo: repoWithOwner, term, number, category, ...pagination } = params;
 
   // Force repo to lowercase to prevent GitHub's bug when using category in query.
-  // https://github.com/laymonage/giscus/issues/118
+  // https://github.com/giscus/giscus/issues/118
   const repo = repoWithOwner.toLowerCase();
   const categoryQuery = category ? `category:${JSON.stringify(category)}` : '';
   const query = `repo:${repo} ${categoryQuery} in:title ${term}`;


### PR DESCRIPTION
Vercel has sponsored our project! Now, we can finally move the repo to the organization :partying_face: 