### PR TITLE
Improve comment replies pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ major updates to the project.
 
 ### changed
 
+- Improve comment replies pagination
+  ([#184](https://github.com/giscus/giscus/pull/184)).
 - Statically render the onboarding comment
   ([#183](https://github.com/giscus/giscus/pull/183)).
 

--- a/components/Comment.tsx
+++ b/components/Comment.tsx
@@ -18,6 +18,14 @@ interface ICommentProps {
   renderReplyBox?: (viewMore: VoidFunction) => ReactElement<typeof CommentBox>;
 }
 
+function pluralizeUpvotes(count: number) {
+  return count === 1 ? 'upvote' : 'upvotes';
+}
+
+function pluralizeReply(count: number) {
+  return count === 1 ? 'reply' : 'replies';
+}
+
 export default function Comment({
   children,
   comment,
@@ -31,6 +39,7 @@ export default function Comment({
   const remainingReplies = comment.replyCount - replies.length;
 
   const hasNextPage = replies.length < comment.replies.length;
+  const hasUnfetchedReplies = !hasNextPage && remainingReplies > 0;
 
   const { token } = useContext(AuthContext);
 
@@ -162,7 +171,7 @@ export default function Comment({
 
                 <span
                   className="gsc-upvote-count"
-                  title={`${comment.upvoteCount} upvote${comment.upvoteCount !== 1 ? 's' : ''}`}
+                  title={`${comment.upvoteCount} ${pluralizeUpvotes(comment.upvoteCount)}`}
                 >
                   {comment.upvoteCount}
                 </span>
@@ -177,7 +186,7 @@ export default function Comment({
             </div>
             <div className="gsc-comment-replies-count">
               <span className="text-xs color-text-tertiary">
-                {comment.replies.length}&nbsp;{comment.replies.length === 1 ? 'reply' : 'replies'}
+                {comment.replies.length}&nbsp;{pluralizeReply(comment.replies.length)}
               </span>
             </div>
           </div>
@@ -188,15 +197,28 @@ export default function Comment({
               renderReplyBox && !hidden ? 'border-b' : 'rounded-b-md'
             }`}
           >
-            {hasNextPage ? (
+            {hasNextPage || hasUnfetchedReplies ? (
               <div className="flex items-center h-8 pl-4 mb-2">
                 <div className="flex content-center flex-shrink-0 mr-[9px] w-[29px]">
                   <KebabHorizontalIcon className="w-full rotate-90 fill-[var(--color-border-muted)]" />
                 </div>
 
-                <button className="color-text-link hover:underline" onClick={incrementBackPage}>
-                  Show {remainingReplies} previous {remainingReplies === 1 ? 'reply' : 'replies'}
-                </button>
+                {hasNextPage ? (
+                  <button className="color-text-link hover:underline" onClick={incrementBackPage}>
+                    Show {remainingReplies} previous {pluralizeReply(remainingReplies)}
+                  </button>
+                ) : null}
+
+                {hasUnfetchedReplies ? (
+                  <a
+                    href={comment.url}
+                    className="color-text-link hover:underline"
+                    rel="nofollow noopener noreferrer"
+                    target="_blank"
+                  >
+                    See {remainingReplies} previous {pluralizeReply(remainingReplies)} on GitHub
+                  </a>
+                ) : null}
               </div>
             ) : null}
 

--- a/components/Comment.tsx
+++ b/components/Comment.tsx
@@ -186,7 +186,7 @@ export default function Comment({
             </div>
             <div className="gsc-comment-replies-count">
               <span className="text-xs color-text-tertiary">
-                {comment.replies.length}&nbsp;{pluralizeReply(comment.replies.length)}
+                {comment.replyCount}&nbsp;{pluralizeReply(comment.replyCount)}
               </span>
             </div>
           </div>

--- a/components/Comment.tsx
+++ b/components/Comment.tsx
@@ -13,9 +13,9 @@ import { AuthContext } from '../lib/context';
 interface ICommentProps {
   children?: ReactNode;
   comment: IComment;
+  replyBox?: ReactElement<typeof CommentBox>;
   onCommentUpdate?: (newComment: IComment, promise: Promise<unknown>) => void;
   onReplyUpdate?: (newReply: IReply, promise: Promise<unknown>) => void;
-  renderReplyBox?: (viewMore: VoidFunction) => ReactElement<typeof CommentBox>;
 }
 
 function pluralizeUpvotes(count: number) {
@@ -29,9 +29,9 @@ function pluralizeReply(count: number) {
 export default function Comment({
   children,
   comment,
+  replyBox,
   onCommentUpdate,
   onReplyUpdate,
-  renderReplyBox,
 }: ICommentProps) {
   const [backPage, setBackPage] = useState(0);
 
@@ -154,7 +154,7 @@ export default function Comment({
         {!comment.isMinimized && onCommentUpdate ? (
           <div
             className={`flex content-center justify-between ${
-              renderReplyBox || comment.replies.length > 0 ? 'border-b' : ''
+              !!replyBox || comment.replies.length > 0 ? 'border-b' : ''
             }${comment.replies.length > 0 ? ' rounded-b-md' : ''}`}
           >
             <div className="gsc-comment-reactions">
@@ -194,7 +194,7 @@ export default function Comment({
         {comment.replies.length > 0 ? (
           <div
             className={`color-bg-canvas-inset color-border-primary gsc-replies ${
-              renderReplyBox && !hidden ? 'border-b' : 'rounded-b-md'
+              !!replyBox && !hidden ? 'border-b' : 'rounded-b-md'
             }`}
           >
             {hasNextPage || hasUnfetchedReplies ? (
@@ -230,7 +230,7 @@ export default function Comment({
           </div>
         ) : null}
 
-        {!comment.isMinimized && renderReplyBox ? renderReplyBox(incrementBackPage) : null}
+        {!comment.isMinimized && !!replyBox ? replyBox : null}
       </div>
     </div>
   );

--- a/components/CommentBox.tsx
+++ b/components/CommentBox.tsx
@@ -14,7 +14,6 @@ interface CommentBoxProps {
   context?: string;
   replyToId?: string;
   onSubmit: (comment: IComment | IReply) => void;
-  onReplyOpen?: VoidFunction;
   onDiscussionCreateRequest?: () => Promise<string>;
 }
 
@@ -24,7 +23,6 @@ export default function CommentBox({
   context,
   replyToId,
   onSubmit,
-  onReplyOpen,
   onDiscussionCreateRequest,
 }: CommentBoxProps) {
   const [isPreview, setIsPreview] = useState(false);
@@ -95,10 +93,9 @@ export default function CommentBox({
     reset,
   ]);
 
-  const handleReplyOpen = useCallback(() => {
-    onReplyOpen();
+  const handleReplyOpen = () => {
     setIsReplyOpen(true);
-  }, [onReplyOpen]);
+  };
 
   const handleTextAreaChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
     setInput(event.target.value);

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -133,22 +133,19 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
                 <Comment
                   key={comment.id}
                   comment={comment}
+                  replyBox={
+                    token && !data.isLocked ? (
+                      <CommentBox
+                        discussionId={data.discussion.id}
+                        context={repo}
+                        onSubmit={frontMutators.addNewReply}
+                        replyToId={comment.id}
+                        viewer={data.viewer}
+                      />
+                    ) : undefined
+                  }
                   onCommentUpdate={frontMutators.updateComment}
                   onReplyUpdate={frontMutators.updateReply}
-                  renderReplyBox={
-                    token && !data.isLocked
-                      ? (viewMore) => (
-                          <CommentBox
-                            discussionId={data.discussion.id}
-                            context={repo}
-                            onSubmit={frontMutators.addNewReply}
-                            replyToId={comment.id}
-                            viewer={data.viewer}
-                            onReplyOpen={viewMore}
-                          />
-                        )
-                      : undefined
-                  }
                 />
               ))
             : null}
@@ -175,22 +172,19 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
                 <Comment
                   key={comment.id}
                   comment={comment}
+                  replyBox={
+                    token && !data.isLocked ? (
+                      <CommentBox
+                        discussionId={data.discussion.id}
+                        context={repo}
+                        onSubmit={backMutators.addNewReply}
+                        replyToId={comment.id}
+                        viewer={data.viewer}
+                      />
+                    ) : undefined
+                  }
                   onCommentUpdate={backMutators.updateComment}
                   onReplyUpdate={backMutators.updateReply}
-                  renderReplyBox={
-                    token && !data.isLocked
-                      ? (viewMore) => (
-                          <CommentBox
-                            discussionId={data.discussion.id}
-                            context={repo}
-                            onSubmit={backMutators.addNewReply}
-                            replyToId={comment.id}
-                            viewer={data.viewer}
-                            onReplyOpen={viewMore}
-                          />
-                        )
-                      : undefined
-                  }
                 />
               ))
             : null}

--- a/services/github/getDiscussion.ts
+++ b/services/github/getDiscussion.ts
@@ -53,7 +53,7 @@ const DISCUSSION_QUERY = `
         }
         viewerHasReacted
       }
-      replies(first: 100) {
+      replies(last: 100) {
         totalCount
         nodes {
           id

--- a/styles/themes/custom_example.css
+++ b/styles/themes/custom_example.css
@@ -15,6 +15,7 @@ main {
   --color-border-secondary: #21262d;
   --color-border-tertiary: rgba(110, 118, 129, 0.4);
   --color-border-info: #1f6feb;
+  --color-border-muted: #373e47;
   --color-bg-canvas: #15202b;
   --color-bg-canvas-inset: rgba(21, 32, 43, 1);
   --color-bg-primary: rgb(25, 39, 52);

--- a/styles/themes/dark.css
+++ b/styles/themes/dark.css
@@ -14,6 +14,7 @@ main {
   --color-border-secondary: #21262d;
   --color-border-tertiary: rgba(110, 118, 129, 0.4);
   --color-border-info: #1f6feb;
+  --color-border-muted: #21262d;
   --color-bg-canvas: #0d1117;
   --color-bg-canvas-inset: #010409;
   --color-bg-primary: #0d1117;

--- a/styles/themes/dark_dimmed.css
+++ b/styles/themes/dark_dimmed.css
@@ -14,6 +14,7 @@ main {
   --color-border-secondary: #373e47;
   --color-border-tertiary: rgba(99, 110, 123, 0.4);
   --color-border-info: #316dca;
+  --color-border-muted: #373e47;
   --color-bg-canvas: #22272e;
   --color-bg-canvas-inset: #1c2128;
   --color-bg-primary: #22272e;

--- a/styles/themes/dark_high_contrast.css
+++ b/styles/themes/dark_high_contrast.css
@@ -14,6 +14,7 @@ main {
   --color-border-secondary: #7a828e;
   --color-border-tertiary: rgba(158, 167, 179, 0.4);
   --color-border-info: #409eff;
+  --color-border-muted: #7a828e;
   --color-bg-canvas: #0a0c10;
   --color-bg-canvas-inset: #010409;
   --color-bg-primary: #0a0c10;

--- a/styles/themes/light.css
+++ b/styles/themes/light.css
@@ -14,6 +14,7 @@ main {
   --color-border-secondary: #d8dee4;
   --color-border-tertiary: rgba(175, 184, 193, 0.4);
   --color-border-info: #0969da;
+  --color-border-muted: hsla(210, 18%, 87%, 1);
   --color-bg-canvas: #fff;
   --color-bg-canvas-inset: #f6f8fa;
   --color-bg-primary: #fff;

--- a/styles/themes/preferred_color_scheme.css
+++ b/styles/themes/preferred_color_scheme.css
@@ -14,6 +14,7 @@ main {
   --color-border-secondary: #d8dee4;
   --color-border-tertiary: rgba(175, 184, 193, 0.4);
   --color-border-info: #0969da;
+  --color-border-muted: hsla(210, 18%, 87%, 1);
   --color-bg-canvas: #fff;
   --color-bg-canvas-inset: #f6f8fa;
   --color-bg-primary: #fff;
@@ -129,6 +130,7 @@ main {
     --color-border-secondary: #21262d;
     --color-border-tertiary: rgba(110, 118, 129, 0.4);
     --color-border-info: #1f6feb;
+    --color-border-muted: #21262d;
     --color-bg-canvas: #0d1117;
     --color-bg-canvas-inset: #010409;
     --color-bg-primary: #0d1117;

--- a/styles/themes/transparent_dark.css
+++ b/styles/themes/transparent_dark.css
@@ -15,6 +15,7 @@ main {
   --color-border-secondary: #21262d;
   --color-border-tertiary: #6e7681;
   --color-border-info: rgba(56, 139, 253, 0.4);
+  --color-border-muted: #21262d;
   --color-bg-canvas: transparent;
   --color-bg-canvas-inset: transparent;
   --color-bg-primary: transparent;


### PR DESCRIPTION
Pagination for replies are now done from the back to match GitHub's new UI. As a temporary workaround for #32, a link to the comment on GitHub will be shown if there are more than 100 replies, indicating the number of comments before the last 100.