### PR TITLE
Log error if response.data is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ writing, this is a rolling-release project without any meaningful versioning
 whatsoever. Tags/releases may be created for the sole purpose of documenting
 major updates to the project.
 
+## 2021-10-04
+
+### changed
+
+- Log error if `response.data` is undefined
+  ([#189](https://github.com/giscus/giscus/pull/189)).
+
 ## 2021-10-03
 
 ### added

--- a/pages/api/discussions/index.ts
+++ b/pages/api/discussions/index.ts
@@ -43,6 +43,12 @@ async function get(req: NextApiRequest, res: NextApiResponse<IGiscussion | IErro
   }
 
   const { data } = response;
+  if (!data) {
+    console.error({ response });
+    res.status(500).json({ error: 'Unable to fetch discussion.' });
+    return;
+  }
+
   const { viewer } = data;
 
   let discussion: GRepositoryDiscussion;


### PR DESCRIPTION
We're getting abnormal number of requests that result in errors from a specific repository. Might be related to #188. For now, let's log these errors and see why this happens.

![Screenshot from 2021-10-04 22-15-43](https://user-images.githubusercontent.com/6379424/135877700-9630753d-62ba-47e1-b557-79ff407c2a60.png)

