### PR TITLE
Add comments count endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ SUPABASE_INSTALLATION_ACCESS_TOKENS_TABLE=installation_access_tokens
 # The usage is different from the values in giscus.json.
 ORIGINS=["https://giscus.app", "https://giscus.vercel.app"]
 ORIGINS_REGEX=["http://localhost:[0-9]+"]
+
+ENABLE_ADDITIONAL_PAGES=true

--- a/lib/types/github.ts
+++ b/lib/types/github.ts
@@ -79,6 +79,12 @@ export interface GRepositoryDiscussion {
   };
 }
 
+export interface GRepositoryDiscussionCount {
+  comments: {
+    totalCount: number;
+  }
+}
+
 export interface GDiscussionCategory {
   id: string;
   name: string;

--- a/pages/api/discussions/comments-count.ts
+++ b/pages/api/discussions/comments-count.ts
@@ -66,6 +66,6 @@ export default async function get(req: NextApiRequest, res: NextApiResponse<numb
   }
 
 
-  res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=900, stale-if-error=86400');
+  res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=3600, stale-if-error=86400');
   res.status(200).json(discussion.comments.totalCount);
 }

--- a/pages/api/discussions/comments-count.ts
+++ b/pages/api/discussions/comments-count.ts
@@ -4,7 +4,11 @@ import { DiscussionQuery } from "../../../lib/types/common";
 import { getAppAccessToken } from "../../../services/github/getAppAccessToken";
 import { getDiscussionCommentsCount } from "../../../services/github/getDiscussionCommentsCount";
 
-export default async function get(req: NextApiRequest, res: NextApiResponse<number | IError>) {
+export default async function getCommentsCount(req: NextApiRequest, res: NextApiResponse<number | IError>) {
+  if (!process.env.ENABLE_ADDITIONAL_PAGES) {
+    return res.status(404).end();
+  }
+
   const params: DiscussionQuery = {
     repo: req.query.repo as string,
     term: req.query.term as string,

--- a/pages/api/discussions/comments-count.ts
+++ b/pages/api/discussions/comments-count.ts
@@ -1,0 +1,71 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { IError } from "../../../lib/types/adapter";
+import { DiscussionQuery } from "../../../lib/types/common";
+import { getAppAccessToken } from "../../../services/github/getAppAccessToken";
+import { getDiscussionCommentsCount } from "../../../services/github/getDiscussionCommentsCount";
+
+export default async function get(req: NextApiRequest, res: NextApiResponse<number | IError>) {
+  const params: DiscussionQuery = {
+    repo: req.query.repo as string,
+    term: req.query.term as string,
+    number: +req.query.number,
+    category: req.query.category as string
+  };
+
+  const userToken = req.headers.authorization?.split('Bearer ')[1];
+  let token = userToken;
+  if (!token) {
+    try {
+      token = await getAppAccessToken(params.repo);
+    } catch (error) {
+      res.status(403).json({ error: error.message });
+      return;
+    }
+  }
+
+  const response = await getDiscussionCommentsCount(params, token);
+
+  if ('message' in response) {
+    if (response.message.includes('Bad credentials')) {
+      res.status(403).json({ error: response.message });
+      return;
+    }
+    res.status(500).json({ error: response.message });
+    return;
+  }
+
+  if ('errors' in response) {
+    const error = response.errors[0];
+    if (error?.message?.includes('API rate limit exceeded')) {
+      let message = `API rate limit exceeded for ${params.repo}`;
+      if (!userToken) {
+        message += '. Sign in to increase the rate limit';
+      }
+      res.status(429).json({ error: message });
+      return;
+    }
+
+    console.error(response);
+    const message = response.errors.map?.(({ message }) => message).join('. ') || 'Unknown error';
+    res.status(500).json({ error: message });
+    return;
+  }
+
+  const { data } = response;
+  if (!data) {
+    console.error(response);
+    res.status(500).json({ error: 'Unable to fetch discussion' });
+    return;
+  }
+
+  const discussion = 'search' in data ? data.search.nodes[0] ?? null : data.repository.discussion;
+
+  if (!discussion) {
+    res.status(404).json({ error: 'Discussion not found' });
+    return;
+  }
+
+
+  res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=900, stale-if-error=86400');
+  res.status(200).json(discussion.comments.totalCount);
+}

--- a/services/github/errors.ts
+++ b/services/github/errors.ts
@@ -1,0 +1,36 @@
+import { GError, GMultipleErrors } from '../../lib/types/github';
+
+export function handleGithubDiscussionResponse<Data>(
+  response: { data: Data } | GError | GMultipleErrors,
+  repo: string,
+  userToken?: string,
+) {
+  if ('message' in response) {
+    if (response.message.includes('Bad credentials')) {
+      return { status: 403, error: response.message };
+    }
+    return { status: 500, error: response.message };
+  }
+
+  if ('errors' in response) {
+    const error = response.errors[0];
+    if (error?.message?.includes('API rate limit exceeded')) {
+      let message = `API rate limit exceeded for ${repo}`;
+      if (!userToken) {
+        message += '. Sign in to increase the rate limit';
+      }
+      return { status: 429, error: message };
+    }
+
+    console.error(response);
+    const message = response.errors.map?.(({ message }) => message).join('. ') || 'Unknown error';
+    return { status: 500, error: message };
+  }
+
+  const { data } = response;
+  if (!data) {
+    console.error(response);
+    return { status: 500, error: 'Unable to fetch discussion' };
+  }
+  return data;
+}

--- a/services/github/getDiscussionCommentsCount.ts
+++ b/services/github/getDiscussionCommentsCount.ts
@@ -1,0 +1,82 @@
+import { DiscussionQuery } from '../../lib/types/common';
+import { GError, GMultipleErrors, GRepositoryDiscussionCount } from '../../lib/types/github';
+import { parseRepoWithOwner } from '../../lib/utils';
+import { GITHUB_GRAPHQL_API_URL } from '../config';
+
+const DISCUSSION_QUERY = `
+  comments {
+    totalCount
+  }`;
+
+const SEARCH_QUERY = `
+  search(type: DISCUSSION last: 1 query: $query) {
+    nodes {
+      ... on Discussion {
+        ${DISCUSSION_QUERY}
+      }
+    }
+  }`;
+
+const SPECIFIC_QUERY = `
+  repository(owner: $owner, name: $name) {
+    discussion(number: $number) {
+      ${DISCUSSION_QUERY}
+    }
+  }
+`;
+
+const GET_DISCUSSION_QUERY = (type: 'term' | 'number') => `
+  query(${
+    type === 'term' ? '$query: String!' : '$owner: String! $name: String! $number: Int!'
+  }) {
+    ${type === 'term' ? SEARCH_QUERY : SPECIFIC_QUERY}
+  }`;
+
+export interface GetDiscussionCommentsCountParams extends DiscussionQuery {}
+
+interface SearchResponse {
+  data: {
+    search: {
+      nodes: Array<GRepositoryDiscussionCount>;
+    };
+  };
+}
+
+interface SpecificResponse {
+  data: {
+    repository: {
+      discussion: GRepositoryDiscussionCount;
+    };
+  };
+}
+
+type GetDiscussionCommentsCountResponse = SearchResponse | SpecificResponse;
+
+export async function getDiscussionCommentsCount(
+  params: GetDiscussionCommentsCountParams,
+  token: string,
+): Promise<GetDiscussionCommentsCountResponse | GError | GMultipleErrors> {
+  const { repo: repoWithOwner, term, number, category, ...pagination } = params;
+
+  // Force repo to lowercase to prevent GitHub's bug when using category in query.
+  // https://github.com/giscus/giscus/issues/118
+  const repo = repoWithOwner.toLowerCase();
+  const categoryQuery = category ? `category:${JSON.stringify(category)}` : '';
+  const query = `repo:${repo} ${categoryQuery} in:title ${term}`;
+  const gql = GET_DISCUSSION_QUERY(number ? 'number' : 'term');
+
+  return fetch(GITHUB_GRAPHQL_API_URL, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+
+    body: JSON.stringify({
+      query: gql,
+      variables: {
+        repo,
+        query,
+        number,
+        ...parseRepoWithOwner(repo),
+      },
+    }),
+  }).then((r) => r.json());
+}

--- a/services/github/getDiscussionCommentsCount.ts
+++ b/services/github/getDiscussionCommentsCount.ts
@@ -1,3 +1,4 @@
+import { DiscussionQuery } from '../../lib/types/common';
 import { GError, GMultipleErrors, GRepositoryDiscussionCount } from '../../lib/types/github';
 import { parseRepoWithOwner } from '../../lib/utils';
 import { GITHUB_GRAPHQL_API_URL } from '../config';

--- a/services/github/getDiscussionCommentsCount.ts
+++ b/services/github/getDiscussionCommentsCount.ts
@@ -1,4 +1,3 @@
-import { DiscussionQuery } from '../../lib/types/common';
 import { GError, GMultipleErrors, GRepositoryDiscussionCount } from '../../lib/types/github';
 import { parseRepoWithOwner } from '../../lib/utils';
 import { GITHUB_GRAPHQL_API_URL } from '../config';
@@ -32,8 +31,6 @@ const GET_DISCUSSION_QUERY = (type: 'term' | 'number') => `
     ${type === 'term' ? SEARCH_QUERY : SPECIFIC_QUERY}
   }`;
 
-export interface GetDiscussionCommentsCountParams extends DiscussionQuery {}
-
 interface SearchResponse {
   data: {
     search: {
@@ -53,10 +50,10 @@ interface SpecificResponse {
 type GetDiscussionCommentsCountResponse = SearchResponse | SpecificResponse;
 
 export async function getDiscussionCommentsCount(
-  params: GetDiscussionCommentsCountParams,
+  params: DiscussionQuery,
   token: string,
 ): Promise<GetDiscussionCommentsCountResponse | GError | GMultipleErrors> {
-  const { repo: repoWithOwner, term, number, category, ...pagination } = params;
+  const { repo: repoWithOwner, term, number, category } = params;
 
   // Force repo to lowercase to prevent GitHub's bug when using category in query.
   // https://github.com/giscus/giscus/issues/118

--- a/services/github/getDiscussionCommentsCount.ts
+++ b/services/github/getDiscussionCommentsCount.ts
@@ -48,7 +48,7 @@ interface SpecificResponse {
   };
 }
 
-type GetDiscussionCommentsCountResponse = SearchResponse | SpecificResponse;
+export type GetDiscussionCommentsCountResponse = SearchResponse | SpecificResponse;
 
 export async function getDiscussionCommentsCount(
   params: DiscussionQuery,

--- a/services/github/graphql.ts
+++ b/services/github/graphql.ts
@@ -1,0 +1,46 @@
+import { GError, GMultipleErrors } from '../../lib/types/github';
+import { parseRepoWithOwner } from '../../lib/utils';
+import { GITHUB_GRAPHQL_API_URL } from '../config';
+
+export async function githubDiscussionGraphqlRequest<
+  Response,
+  AdditionalVariables = Record<string, never>,
+>({
+  gql,
+  repoWithOwner,
+  category,
+  term,
+  token,
+  number,
+  variables,
+}: {
+  gql: string;
+  repoWithOwner: string;
+  category: string;
+  term: string;
+  token: string;
+  number: number;
+  variables: AdditionalVariables;
+}): Promise<Response | GError | GMultipleErrors> {
+  // Force repo to lowercase to prevent GitHub's bug when using category in query.
+  // https://github.com/giscus/giscus/issues/118
+  const repo = repoWithOwner.toLowerCase();
+  const categoryQuery = category ? `category:${JSON.stringify(category)}` : '';
+  const query = `repo:${repo} ${categoryQuery} in:title ${term}`;
+
+  return fetch(GITHUB_GRAPHQL_API_URL, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+
+    body: JSON.stringify({
+      query: gql,
+      variables: {
+        repo,
+        query,
+        number,
+        ...parseRepoWithOwner(repo),
+        ...variables,
+      },
+    }),
+  }).then((r) => r.json());
+}


### PR DESCRIPTION
A custom API route for getting comment count. Useful for more advanced use-cases such as fetching & displaying the number of comments below each blogpost. 

Obviously, this is just a draft because there's plenty of repetitive code to `pages/api/discussions/index.ts`.

Fixes #145