### PR TITLE
chore: Use new setup-node caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - uses: actions/cache@v2
         with:
           path: .eslintcache
@@ -33,6 +22,8 @@ jobs:
             eslint
 
       - uses: actions/setup-node@v2
+        with:
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
This is now supported as part of the Action https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies