### PR TITLE
chore: Add Next.js recommended CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ jobs:
 
       - uses: actions/cache@v2
         with:
+          path: ${{ github.workspace }}/.next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
+
+      - uses: actions/cache@v2
+        with:
           path: .eslintcache
           key: eslint
           restore-keys: |


### PR DESCRIPTION
From https://nextjs.org/docs/messages/no-cache modified for Yarn

Got this from the previous CI run warning