### PR TITLE
Change Polish "no comments" string to have capital letter at the beginning 

### DIFF
--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -1,6 +1,6 @@
 {
   "reactions": {
-    "0": "brak reakcji",
+    "0": "Brak reakcji",
     "one": "{{count}} reakcja",
     "few": "{{count}} reakcje",
     "many": "{{count}} reakcji",
@@ -8,7 +8,7 @@
   },
   "comment": "Skomentuj",
   "comments": {
-    "0": "brak komentarzy",
+    "0": "Brak komentarzy",
     "one": "{{count}} komentarz",
     "few": "{{count}} komentarze",
     "many": "{{count}} komentarzy",


### PR DESCRIPTION
Hi!

That's awesome, that Giscus is available in Polish but one small thing that is nice to have in it, is the capital letter at the beginning of the "0 comments" string (ofc. in Polish version). To not have something like this:

<img width="560" alt="brak komentarzy" src="https://user-images.githubusercontent.com/25187173/149372836-01123d0b-4a17-4a5b-b70f-73bbb9b1f7d5.png">

but like this:

<img width="567" alt="Brak komentarzy" src="https://user-images.githubusercontent.com/25187173/149372865-510edacb-7a1d-437e-a062-3f3ddd779129.png">

If you agree with you, I would appreciate addding this PR to the codebase 😌



