### PR TITLE
Add missing Cache-Control to client.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -47,7 +47,7 @@ module.exports = withBundleAnalyzer(
             headers: securityHeaders,
           },
           {
-            source: '/themes/(.*)',
+            source: '/(themes/(?:.*)|client\\.js)',
             headers: [
               {
                 key: 'Cache-Control',


### PR DESCRIPTION
The [`client.js`](https://giscus.app/client.js) have no `Cache-Control` header so it won't be cached. Let's add it.