### PR TITLE
Add buttons to order comments by oldest and newest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,13 @@ major updates to the project.
   ([#355](https://github.com/giscus/giscus/pull/355)).
 
 - Add `inputPosition` option to place the comment box above the comments
-  ([#358](https://github.com/giscus/giscus/pull/358)).
+  ([#358](https://github.com/giscus/giscus/pull/358)). \
+  **Note:** the `gsc-comment-box-separator` class has been removed.
+
+- Add buttons to order comments by oldest and newest
+  ([#372](https://github.com/giscus/giscus/pull/372)). \
+  **Note:** you'll need to add `--color-btn-selected-bg` and
+  `--color-primer-shadow-inset` variables if you use a custom CSS.
 
 ## 2022-01-16
 

--- a/components/CommentBox.tsx
+++ b/components/CommentBox.tsx
@@ -213,7 +213,7 @@ export default function CommentBox({
         <div className="gsc-comment-box-buttons">
           {isReply ? (
             <button
-              className="px-4 py-[5px] ml-1 border rounded-md btn"
+              className="ml-1 border rounded-md btn"
               onClick={() => setIsReplyOpen(false)}
               type="button"
             >
@@ -222,7 +222,7 @@ export default function CommentBox({
           ) : null}
           {token ? (
             <button
-              className="px-4 py-[5px] ml-1 border rounded-md items-center btn btn-primary"
+              className="ml-1 border rounded-md items-center btn btn-primary"
               type="submit"
               disabled={(token && !input.trim()) || isSubmitting}
             >
@@ -230,7 +230,7 @@ export default function CommentBox({
             </button>
           ) : (
             <a
-              className="px-4 py-[5px] ml-1 border hover:no-underline rounded-md inline-flex items-center btn btn-primary"
+              className="ml-1 border hover:no-underline rounded-md inline-flex items-center btn btn-primary"
               target="_top"
               href={loginUrl}
             >

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -154,7 +154,7 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
                 role="option"
                 onClick={() => setOrderBy('oldest')}
               >
-                Oldest
+                {t('oldest')}
               </button>
               <button
                 className="btn BtnGroup-item"
@@ -162,7 +162,7 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
                 role="option"
                 onClick={() => setOrderBy('newest')}
               >
-                Newest
+                {t('newest')}
               </button>
             </div>
           ) : null}

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -32,6 +32,8 @@
   "loadingComments": "Lade Kommentare…",
   "loadingPreview": "Lade Vorschau…",
   "poweredBy": "– Unterstützt von <a>giscus</a>",
+  "oldest": "Älteste",
+  "newest": "Neueste",
   "showPreviousReplies": {
     "0": "Zeige {{count}} vorherige Antworten",
     "one": "Zeige {{count}} vorherige Antwort",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -32,6 +32,8 @@
   "loadingComments": "Loading comments…",
   "loadingPreview": "Loading preview…",
   "poweredBy": "– powered by <a>giscus</a>",
+  "oldest": "Oldest",
+  "newest": "Newest",
   "showPreviousReplies": {
     "0": "Show {{count}} previous replies",
     "one": "Show {{count}} previous reply",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -32,6 +32,8 @@
   "loadingComments": "Cargando comentarios…",
   "loadingPreview": "Cargando vista previa…",
   "poweredBy": "– Desarrollado por <a>giscus</a>",
+  "oldest": "Antiguo",
+  "newest": "Nuevo",
   "showPreviousReplies": {
     "0": "Mostrar {{count}} respuestas anteriores",
     "one": "Mostrar {{count}} respuesta anteriores",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -32,6 +32,8 @@
   "loadingComments": "Chargement des commentaires…",
   "loadingPreview": "Chargement de l'aperçu…",
   "poweredBy": "– propulsé par <a>giscus</a>",
+  "oldest": "Ancien",
+  "newest": "Dernier",
   "showPreviousReplies": {
     "0": "Afficher {{count}} réponse précédénte",
     "one": "Afficher {{count}} réponse précédénte",

--- a/locales/gsw/common.json
+++ b/locales/gsw/common.json
@@ -32,6 +32,8 @@
   "loadingComments": "Lade Kommentare…",
   "loadingPreview": "Lade Vorschau…",
   "poweredBy": "– Unterstützt von <a>giscus</a>",
+  "oldest": "Älteste",
+  "newest": "Neueste",
   "showPreviousReplies": {
     "0": "Zeige {{count}} vorherige Antworten",
     "one": "Zeige {{count}} vorherige Antwort",

--- a/locales/id/common.json
+++ b/locales/id/common.json
@@ -22,6 +22,8 @@
   "loadingComments": "Memuat komentar…",
   "loadingPreview": "Memuat pratinjau…",
   "poweredBy": "– diberdayakan oleh <a>giscus</a>",
+  "oldest": "Terlama",
+  "newest": "Terbaru",
   "showPreviousReplies": {
     "other": "Tampilkan {{count}} balasan sebelumnya"
   },

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -32,6 +32,8 @@
   "loadingComments": "Carico commenti…",
   "loadingPreview": "Carico anteprima…",
   "poweredBy": "– da <a>giscus</a>",
+  "oldest": "Vecchio",
+  "newest": "Recente",
   "showPreviousReplies": {
     "0": "Mostra {{count}} risposte precedenti",
     "one": "Mostra {{count}} risposta precedente",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -32,6 +32,8 @@
   "loadingComments": "コメントを取得中…",
   "loadingPreview": "プレビューを読み込み中…",
   "poweredBy": "– <a>giscus</a>を搭載",
+  "oldest": "最古",
+  "newest": "最新",
   "showPreviousReplies": {
     "0": "{{count}}件前の返信を表示",
     "one": "{{count}}件前の返信を表示",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -32,6 +32,8 @@
   "loadingComments": "댓글 불러오는 중…",
   "loadingPreview": "미리 보기 로딩 중…",
   "poweredBy": "– <a>giscus</a>에 의해 구동",
+  "oldest": "가장 오래된",
+  "newest": "최신",
   "showPreviousReplies": {
     "0": "이전 답글 {{count}} 개 더 보기",
     "one": "이전 답글 {{count}} 개 더 보기",

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -42,6 +42,8 @@
   "loadingComments": "Wczytywanie komentarzy…",
   "loadingPreview": "Wczytywanie podglądu…",
   "poweredBy": "– zasilane przez <a>giscus</a>",
+  "oldest": "Najstarszego",
+  "newest": "Najnowszego",
   "showPreviousReplies": {
     "0": "Pokaż {{count}} poprzednich odpowiedzi",
     "one": "Pokaż poprzednią odpowiedź",

--- a/locales/ro/common.json
+++ b/locales/ro/common.json
@@ -37,6 +37,8 @@
   "loadingComments": "Încărcare comentarii…",
   "loadingPreview": "Încărcare previzualizare…",
   "poweredBy": "– oferit de <a>giscus</a>",
+  "oldest": "Vechi",
+  "newest": "Nou",
   "showPreviousReplies": {
     "0": "Arată {{count}} răspunsuri anterioare",
     "one": "Arată {{count}} răspuns anterior",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -42,6 +42,8 @@
   "loadingComments": "Загрузка комментариев…",
   "loadingPreview": "Загрузка предварительного просмотра…",
   "poweredBy": "– управляется <a>giscus</a>",
+  "oldest": "Старых",
+  "newest": "Новым",
   "showPreviousReplies": {
     "0": "Показать {{count}} предыдущих ответов",
     "one": "Показать {{count}} предыдущий ответ",

--- a/locales/vi/common.json
+++ b/locales/vi/common.json
@@ -32,6 +32,8 @@
   "loadingComments": "Đang tải thêm bình luận…",
   "loadingPreview": "Đang tải bản xem trước…",
   "poweredBy": "– powered by <a>giscus</a>",
+  "oldest": "Cũ",
+  "newest": "Mới",
   "showPreviousReplies": {
     "0": "Hiển thị {{count}} câu trả lời trước đó",
     "one": "Hiển thị {{count}} câu trả lời trước đó",

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -22,6 +22,8 @@
   "loadingComments": "正在加载评论……",
   "loadingPreview": "正在加载预览……",
   "poweredBy": "– 由 <a>giscus</a> 驱动",
+  "oldest": "最旧",
+  "newest": "最新",
   "showPreviousReplies": {
     "other": "显示 {{count}} 条更早的回复"
   },

--- a/locales/zh-TW/common.json
+++ b/locales/zh-TW/common.json
@@ -22,6 +22,8 @@
   "loadingComments": "正在載入留言……",
   "loadingPreview": "正在載入預覽……",
   "poweredBy": "– powered by <a>giscus</a>",
+  "oldest": "最舊",
+  "newest": "最新",
   "showPreviousReplies": {
     "other": "顯示 {{count}} 則更早的回覆"
   },

--- a/services/giscus/discussions.ts
+++ b/services/giscus/discussions.ts
@@ -164,7 +164,13 @@ export function useDiscussion(
   };
 }
 
-export function useFrontBackDiscussion(query: DiscussionQuery, token?: string) {
+export type CommentOrder = 'oldest' | 'newest';
+
+export function useFrontBackDiscussion(
+  query: DiscussionQuery,
+  token?: string,
+  orderBy: CommentOrder = 'oldest',
+) {
   const backDiscussion = useDiscussion(query, token, { last: 15 });
   const {
     data: _backData,
@@ -215,8 +221,11 @@ export function useFrontBackDiscussion(query: DiscussionQuery, token?: string) {
     return newData;
   });
 
-  const backComments = backData?.discussion?.comments || [];
-  const frontComments = frontData?.flatMap((page) => page?.discussion?.comments || []) || [];
+  const _backComments = backData?.discussion?.comments || [];
+  const _frontComments = frontData?.flatMap((page) => page?.discussion?.comments || []) || [];
+
+  const frontComments = orderBy === 'oldest' ? _frontComments : _backComments.slice().reverse();
+  const backComments = orderBy === 'oldest' ? _backComments : _frontComments.slice().reverse();
 
   const updateReactions = useCallback(
     (reaction: Reaction, promise: Promise<unknown>) =>

--- a/styles/base.css
+++ b/styles/base.css
@@ -116,7 +116,7 @@ a {
 }
 
 .btn {
-  @apply relative inline-block align-middle border rounded-md cursor-pointer whitespace-nowrap;
+  @apply px-4 py-[5px] text-sm relative inline-block align-middle border rounded-md cursor-pointer whitespace-nowrap;
 
   color: var(--color-btn-text);
   background-color: var(--color-btn-bg);
@@ -125,6 +125,27 @@ a {
   transition: 0.2s cubic-bezier(0.3, 0, 0.5, 1);
   transition-property: color, background-color, border-color;
   transition-delay: 0s;
+}
+
+.BtnGroup {
+  @apply inline-block align-middle;
+}
+
+.BtnGroup-item {
+  @apply rounded-none;
+}
+
+.BtnGroup-item:first-child:not(:only-child) {
+  @apply rounded-r-none rounded-l;
+}
+
+.BtnGroup-item:last-child:not(:only-child) {
+  @apply rounded-l-none rounded-r;
+}
+
+.BtnGroup-item:not(:first-child):not(:last-child),
+.BtnGroup-item:first-child + .BtnGroup-item:last-child {
+  @apply border-l-0;
 }
 
 .btn:hover {
@@ -139,6 +160,11 @@ a {
 
   background-color: var(--color-btn-active-bg);
   border-color: var(--color-btn-active-border);
+}
+
+.btn[aria-selected="true"] {
+  background-color: var(--color-btn-selected-bg);
+  box-shadow: var(--color-primer-shadow-inset);
 }
 
 .btn-primary {
@@ -340,6 +366,10 @@ a {
   color: var(--color-accent-fg, var(--color-text-link));
 }
 
+.ClipboardButton {
+  @apply p-0 m-2;
+}
+
 img.emoji {
   @apply inline align-top max-w-none;
 
@@ -442,6 +472,10 @@ img.emoji {
 }
 
 .gsc-header {
+  @apply flex flex-auto items-center;
+}
+
+.gsc-left-header {
   @apply flex flex-wrap items-center flex-auto whitespace-nowrap;
 }
 

--- a/styles/themes/custom_example.css
+++ b/styles/themes/custom_example.css
@@ -44,6 +44,7 @@ main {
   --color-btn-hover-border: #768390;
   --color-btn-active-bg: hsl(213deg 12% 27% / 100%);
   --color-btn-active-border: #636e7b;
+  --color-btn-selected-bg: #2d333b;
   --color-btn-primary-text: #fff;
   --color-btn-primary-bg: #347d39;
   --color-btn-primary-border: rgb(205 217 229 / 10%);
@@ -74,6 +75,7 @@ main {
   --color-success-fg: #57ab5a;
   --color-danger-fg: #e5534b;
   --color-primer-shadow-focus: 0 0 0 3px #143d79;
+  --color-primer-shadow-inset: 0 0 transparent;
   --color-scale-gray-7: #373e47;
   --color-scale-gray-8: #2d333b;
   --color-scale-blue-8: #143d79;

--- a/styles/themes/custom_example.css
+++ b/styles/themes/custom_example.css
@@ -99,6 +99,14 @@ main .pagination-loader-container {
   display: none;
 }
 
+.gsc-timeline {
+  flex-direction: column-reverse;
+}
+
+.gsc-header {
+  padding-bottom: 1rem;
+}
+
 .gsc-comments > .gsc-header {
   order: 1;
 }
@@ -110,14 +118,6 @@ main .pagination-loader-container {
 
 .gsc-comments > .gsc-timeline {
   order: 3;
-}
-
-.gsc-timeline {
-  flex-direction: column-reverse;
-}
-
-.gsc-header {
-  padding-bottom: 1rem;
 }
 
 .gsc-homepage-bg {

--- a/styles/themes/dark.css
+++ b/styles/themes/dark.css
@@ -43,6 +43,7 @@ main {
   --color-btn-hover-border: #8b949e;
   --color-btn-active-bg: hsl(212deg 12% 18% / 100%);
   --color-btn-active-border: #6e7681;
+  --color-btn-selected-bg: #161b22;
   --color-btn-primary-text: #fff;
   --color-btn-primary-bg: #238636;
   --color-btn-primary-border: rgb(240 246 252 / 10%);
@@ -73,6 +74,7 @@ main {
   --color-success-fg: #3fb950;
   --color-danger-fg: #f85149;
   --color-primer-shadow-focus: 0 0 0 3px #0c2d6b;
+  --color-primer-shadow-inset: 0 0 transparent;
   --color-scale-gray-7: #21262d;
   --color-scale-gray-8: #161b22;
   --color-scale-blue-8: #0c2d6b;

--- a/styles/themes/dark_dimmed.css
+++ b/styles/themes/dark_dimmed.css
@@ -43,6 +43,7 @@ main {
   --color-btn-hover-border: #768390;
   --color-btn-active-bg: hsl(213deg 12% 27% / 100%);
   --color-btn-active-border: #636e7b;
+  --color-btn-selected-bg: #2d333b;
   --color-btn-primary-text: #fff;
   --color-btn-primary-bg: #347d39;
   --color-btn-primary-border: rgb(205 217 229 / 10%);
@@ -73,6 +74,7 @@ main {
   --color-success-fg: #57ab5a;
   --color-danger-fg: #e5534b;
   --color-primer-shadow-focus: 0 0 0 3px #143d79;
+  --color-primer-shadow-inset: 0 0 transparent;
   --color-scale-gray-7: #373e47;
   --color-scale-gray-8: #2d333b;
   --color-scale-blue-8: #143d79;

--- a/styles/themes/dark_high_contrast.css
+++ b/styles/themes/dark_high_contrast.css
@@ -43,6 +43,7 @@ main {
   --color-btn-hover-border: #bdc4cc;
   --color-btn-active-bg: hsl(217deg 10% 33% / 100%);
   --color-btn-active-border: #9ea7b3;
+  --color-btn-selected-bg: rgb(82 89 100 / 90%);
   --color-btn-primary-text: #0a0c10;
   --color-btn-primary-bg: #09b43a;
   --color-btn-primary-border: #4ae168;
@@ -73,6 +74,7 @@ main {
   --color-success-fg: #26cd4d;
   --color-danger-fg: #ff6a69;
   --color-primer-shadow-focus: 0 0 0 3px #1e60d5;
+  --color-primer-shadow-inset: 0 0 transparent;
   --color-scale-gray-7: #272b33;
   --color-scale-gray-8: #272b33;
   --color-scale-blue-8: #1e60d5;

--- a/styles/themes/dark_protanopia.css
+++ b/styles/themes/dark_protanopia.css
@@ -43,6 +43,7 @@ main {
   --color-btn-hover-border: #8b949e;
   --color-btn-active-bg: hsl(212deg 12% 18% / 100%);
   --color-btn-active-border: #6e7681;
+  --color-btn-selected-bg: #161b22;
   --color-btn-primary-text: #fff;
   --color-btn-primary-bg: #1d69e0;
   --color-btn-primary-border: rgb(240 246 252 / 10%);
@@ -73,6 +74,7 @@ main {
   --color-success-fg: #42a0ff;
   --color-danger-fg: #c38000;
   --color-primer-shadow-focus: 0 0 0 3px #0c2d6b;
+  --color-primer-shadow-inset: 0 0 transparent;
   --color-scale-gray-7: #424a53;
   --color-scale-gray-8: #32383f;
   --color-scale-blue-8: #0a3069;

--- a/styles/themes/light.css
+++ b/styles/themes/light.css
@@ -43,6 +43,7 @@ main {
   --color-btn-hover-border: rgb(27 31 36 / 15%);
   --color-btn-active-bg: hsl(220deg 14% 93% / 100%);
   --color-btn-active-border: rgb(27 31 36 / 15%);
+  --color-btn-selected-bg: hsl(220deg 14% 94% / 100%);
   --color-btn-primary-text: #fff;
   --color-btn-primary-bg: #2da44e;
   --color-btn-primary-border: rgb(27 31 36 / 15%);
@@ -73,6 +74,7 @@ main {
   --color-success-fg: #1a7f37;
   --color-danger-fg: #cf222e;
   --color-primer-shadow-focus: 0 0 0 3px rgb(9 105 218 / 30%);
+  --color-primer-shadow-inset: inset 0 1px 0 rgb(208 215 222 / 20%);
   --color-scale-gray-0: #f6f8fa;
   --color-scale-gray-1: #eaeef2;
   --color-scale-blue-1: #b6e3ff;

--- a/styles/themes/light_protanopia.css
+++ b/styles/themes/light_protanopia.css
@@ -43,6 +43,7 @@ main {
   --color-btn-hover-border: rgb(27 31 36 / 15%);
   --color-btn-active-bg: hsl(220deg 14% 93% / 100%);
   --color-btn-active-border: rgb(27 31 36 / 15%);
+  --color-btn-selected-bg: hsl(220deg 14% 94% / 100%);
   --color-btn-primary-text: #fff;
   --color-btn-primary-bg: #08f;
   --color-btn-primary-border: rgb(27 31 36 / 15%);
@@ -73,6 +74,7 @@ main {
   --color-success-fg: #0566d5;
   --color-danger-fg: #ac5e00;
   --color-primer-shadow-focus: 0 0 0 3px rgb(9 105 218 / 30%);
+  --color-primer-shadow-inset: inset 0 1px 0 rgb(208 215 222 / 20%);
   --color-scale-gray-0: #f6f8fa;
   --color-scale-gray-1: #eaeef2;
   --color-scale-blue-1: #b6e3ff;

--- a/styles/themes/preferred_color_scheme.css
+++ b/styles/themes/preferred_color_scheme.css
@@ -43,6 +43,7 @@ main {
   --color-btn-hover-border: rgb(27 31 36 / 15%);
   --color-btn-active-bg: hsl(220deg 14% 93% / 100%);
   --color-btn-active-border: rgb(27 31 36 / 15%);
+  --color-btn-selected-bg: hsl(220deg 14% 94% / 100%);
   --color-btn-primary-text: #fff;
   --color-btn-primary-bg: #2da44e;
   --color-btn-primary-border: rgb(27 31 36 / 15%);
@@ -73,6 +74,7 @@ main {
   --color-success-fg: #1a7f37;
   --color-danger-fg: #cf222e;
   --color-primer-shadow-focus: 0 0 0 3px rgb(9 105 218 / 30%);
+  --color-primer-shadow-inset: inset 0 1px 0 rgb(208 215 222 / 20%);
   --color-scale-gray-0: #f6f8fa;
   --color-scale-gray-1: #eaeef2;
   --color-scale-blue-1: #b6e3ff;
@@ -137,6 +139,7 @@ main .pagination-loader-container {
     --color-btn-hover-border: #8b949e;
     --color-btn-active-bg: hsl(212deg 12% 18% / 100%);
     --color-btn-active-border: #6e7681;
+    --color-btn-selected-bg: #161b22;
     --color-btn-primary-text: #fff;
     --color-btn-primary-bg: #238636;
     --color-btn-primary-border: rgb(240 246 252 / 10%);
@@ -167,6 +170,7 @@ main .pagination-loader-container {
     --color-success-fg: #3fb950;
     --color-danger-fg: #f85149;
     --color-primer-shadow-focus: 0 0 0 3px #0c2d6b;
+    --color-primer-shadow-inset: 0 0 transparent;
     --color-scale-gray-7: #21262d;
     --color-scale-gray-8: #161b22;
     --color-scale-blue-8: #0c2d6b;

--- a/styles/themes/transparent_dark.css
+++ b/styles/themes/transparent_dark.css
@@ -36,14 +36,15 @@ main {
   --color-prettylights-syntax-sublimelinter-gutter-mark: #484f58;
   --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
   --color-btn-text: #c9d1d9;
-  --color-btn-bg: #21262d;
+  --color-btn-bg: rgb(45 51 59 / 80%);
   --color-btn-border: rgb(240 246 252 / 10%);
   --color-btn-shadow: 0 0 transparent;
   --color-btn-inset-shadow: 0 0 transparent;
-  --color-btn-hover-bg: #30363d;
+  --color-btn-hover-bg: rgb(45 51 59 / 50%);
   --color-btn-hover-border: #8b949e;
-  --color-btn-active-bg: hsl(212deg 12% 18% / 100%);
+  --color-btn-active-bg: hsl(212deg 12% 18% / 50%);
   --color-btn-active-border: #6e7681;
+  --color-btn-selected-bg: rgb(45 51 59 / 50%);
   --color-btn-primary-text: #fff;
   --color-btn-primary-bg: #238636;
   --color-btn-primary-border: rgb(240 246 252 / 10%);
@@ -74,6 +75,7 @@ main {
   --color-success-fg: #3fb950;
   --color-danger-fg: #f85149;
   --color-primer-shadow-focus: 0 0 0 3px #0c2d6b;
+  --color-primer-shadow-inset: 0 0 transparent;
   --color-scale-gray-7: #21262d;
   --color-scale-blue-8: #0c2d6b;
 


### PR DESCRIPTION
Fix #75. The `Top` ordering isn't available because GitHub hasn't provided ordering capabilities in the Discussions API as of now, and sorting the comments locally isn't a good idea (in this case we just switch and reverse the arrays).