### PR TITLE
Fix crash when rendering footnotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ writing, this is a rolling-release project without any meaningful versioning
 whatsoever. Tags/releases may be created for the sole purpose of documenting
 major updates to the project.
 
+## 2022-02-06
+
+### Fixed
+
+- Fix crash when rendering footnotes
+  ([#382](https://github.com/giscus/giscus/pull/382)).
+
 ## 2022-01-29
 
 ### Added

--- a/lib/adapter.ts
+++ b/lib/adapter.ts
@@ -141,9 +141,15 @@ export function processCommentBody(bodyHTML: string) {
     const currentLink = window.location.href;
 
     if (a.href.startsWith(`${currentLink}#`)) {
-      const parentLocation = window.parent.location;
-      const parentLink = parentLocation.href.replace(parentLocation.hash, '');
-      a.href = `${parentLink}${a.href.substr(currentLink.length)}`;
+      let parentLink: URL;
+      try {
+        parentLink = new URL(document.referrer);
+      } catch {
+        return;
+      }
+
+      parentLink.hash = '';
+      a.href = `${parentLink.href}${a.href.substring(currentLink.length)}`;
       return;
     }
 


### PR DESCRIPTION
`window.parent.location.href` is not accessible from a cross-origin `<iframe>`.