### PR TITLE
Fix crash if a comment author user account has been deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ writing, this is a rolling-release project without any meaningful versioning
 whatsoever. Tags/releases may be created for the sole purpose of documenting
 major updates to the project.
 
+## 2022-02-07
+
+### Fixed
+
+- Fix crash if a comment author user account has been deleted
+  ([#391](https://github.com/giscus/giscus/pull/391)).
+
 ## 2022-02-06
 
 ### Changed

--- a/lib/adapter.ts
+++ b/lib/adapter.ts
@@ -15,6 +15,14 @@ const COPY_BUTTON_HTML = `
   </button>
 </div>`;
 
+// GitHub uses the @ghost user to replace deleted users on the website,
+// but returns `null` in the API.
+const GhostUser: GUser = {
+  avatarUrl: 'https://avatars.githubusercontent.com/u/10137?s=64&v=4',
+  login: 'ghost',
+  url: 'https://github.com/ghost',
+};
+
 export function adaptReactionGroups(reactionGroups: GReactionGroup[]): IReactionGroups {
   return reactionGroups.reduce((acc, group) => {
     acc[group.content] = {
@@ -29,22 +37,25 @@ export function adaptReply(reply: GReply): IReply {
   const {
     reactionGroups,
     replyTo: { id: replyToId },
+    author: _author,
     ...rest
   } = reply;
 
   const reactions = adaptReactionGroups(reactionGroups);
+  const author = _author || GhostUser;
 
-  return { ...rest, reactions, replyToId };
+  return { ...rest, author, reactions, replyToId };
 }
 
 export function adaptComment(comment: GComment): IComment {
-  const { replies: repliesData, reactionGroups, ...rest } = comment;
+  const { replies: repliesData, reactionGroups, author: _author, ...rest } = comment;
   const { totalCount: replyCount, nodes: replyNodes } = repliesData;
 
   const reactions = adaptReactionGroups(reactionGroups);
   const replies = replyNodes.map(adaptReply);
+  const author = _author || GhostUser;
 
-  return { ...rest, replyCount, reactions, replies };
+  return { ...rest, author, replyCount, reactions, replies };
 }
 
 export function adaptDiscussion({

--- a/lib/types/github.ts
+++ b/lib/types/github.ts
@@ -28,7 +28,7 @@ export interface GReactionGroup {
 
 interface GBaseComment {
   id: string;
-  author: GRepositoryDiscussionAuthor;
+  author: GRepositoryDiscussionAuthor | null;
   viewerDidAuthor: boolean;
   createdAt: string;
   url: string;


### PR DESCRIPTION
GitHub uses @ghost on the website to replace deleted users, but returns `null` in the API.