### PR TITLE
Resize iframe with `ResizeObserver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ writing, this is a rolling-release project without any meaningful versioning
 whatsoever. Tags/releases may be created for the sole purpose of documenting
 major updates to the project.
 
+## 2022-02-09
+
+### Changed
+
+- Resize iframe with `ResizeObserver`
+  ([#392](https://github.com/giscus/giscus/pull/392)). \
+  **Note:** if you're using
+  [giscus-component](https://github.com/giscus/giscus-component), please update
+  to the latest version. The previous iframe resizing technique is now
+  deprecated and will be removed in the future.
+
 ## 2022-02-07
 
 ### Fixed

--- a/client.ts
+++ b/client.ts
@@ -1,5 +1,3 @@
-declare let iFrameResize: (options: Record<string, unknown>, selector: string) => void;
-
 (function () {
   const GISCUS_SESSION_KEY = 'giscus-session';
   const script = document.currentScript as HTMLScriptElement;
@@ -8,18 +6,6 @@ declare let iFrameResize: (options: Record<string, unknown>, selector: string) =
   function formatError(message: string) {
     return `[giscus] An error occurred. Error message: "${message}".`;
   }
-
-  // Set up iframeResizer
-  function loadScript(url: string, callback: VoidFunction) {
-    const target = document.createElement('script');
-    target.setAttribute('src', url);
-    target.onload = callback;
-    script.insertAdjacentElement('beforeend', target);
-  }
-
-  loadScript(`${giscusOrigin}/js/iframeResizer.min.js`, () =>
-    iFrameResize({ checkOrigin: [giscusOrigin], resizeFrom: 'child' }, '.giscus-frame'),
-  );
 
   // Set up iframe src URL and params
   const url = new URL(location.href);
@@ -131,12 +117,18 @@ declare let iFrameResize: (options: Record<string, unknown>, selector: string) =
   }
   const suggestion = `Please consider reporting this error at https://github.com/giscus/giscus/issues/new.`;
 
-  // Listen to error messages
+  // Listen to messages
   window.addEventListener('message', (event) => {
     if (event.origin !== giscusOrigin) return;
 
     const { data } = event;
-    if (!(typeof data === 'object' && data?.giscus?.error)) return;
+    if (!(typeof data === 'object' && data.giscus)) return;
+
+    if (data.giscus.resizeHeight) {
+      iframeElement.style.height = `${data.giscus.resizeHeight}px`;
+    }
+
+    if (!data.giscus.error) return;
 
     const message: string = data.giscus.error;
 

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -2,7 +2,7 @@ import { useCallback, useContext, useEffect, useState } from 'react';
 import Giscus from '../components/Giscus';
 import { AuthContext, ConfigContext, getLoginUrl } from '../lib/context';
 import { emitData } from '../lib/messages';
-import { IErrorMessage } from '../lib/types/giscus';
+import { IErrorMessage, IResizeHeightMessage } from '../lib/types/giscus';
 import { createDiscussion } from '../services/giscus/createDiscussion';
 import { getToken } from '../services/giscus/token';
 
@@ -37,6 +37,17 @@ export default function Widget({ origin, session }: IWidgetProps) {
         .catch((err) => handleError(err?.message));
     }
   }, [handleError, session, token]);
+
+  useEffect(() => {
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      emitData<IResizeHeightMessage>({ resizeHeight: entry.contentRect.height }, origin);
+    });
+
+    observer.observe(document.querySelector('body'));
+    return () => observer.disconnect();
+  }, [origin]);
 
   const ready = (!session || token) && repo && (term || number);
 

--- a/lib/types/giscus.ts
+++ b/lib/types/giscus.ts
@@ -47,6 +47,10 @@ export interface IMetadataMessage {
   viewer: IUser;
 }
 
+export interface IResizeHeightMessage {
+  resizeHeight: number;
+}
+
 // parent-to-giscus messages
 export interface ISetConfigMessage {
   setConfig: {

--- a/pages/widget.tsx
+++ b/pages/widget.tsx
@@ -153,6 +153,7 @@ export default function WidgetPage({
         src="/js/iframeResizer.contentWindow.min.js"
         integrity="sha256-rbC2imHDJIBYUIXvf+XiYY+2cXmiSlctlHgI+rrezQo="
         crossOrigin="anonymous"
+        strategy="lazyOnload"
       />
     </>
   );


### PR DESCRIPTION
This replaces [iframe-resizer](https://github.com/davidjbradshaw/iframe-resizer) with a custom solution using the modern built-in [`ResizeObserver`](https://web.dev/resize-observer/). I'd love to remove the `iframeResizer.contentWindow.min.js` script from our widget page, but that'd be a breaking change to the giscus-component users until they (and I) update it to use `ResizeObserver`. We'll have to do that sooner or later, but for now let's just set the script's strategy to `lazyOnload`.

This saves us ~6KB in the client. We can save an additional 5KB if we completely remove the `contentWindow` script from the widget page. Probably would save even more in giscus-component.