### PR TITLE
Improve reaction button popover menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ writing, this is a rolling-release project without any meaningful versioning
 whatsoever. Tags/releases may be created for the sole purpose of documenting
 major updates to the project.
 
+## 2022-03-26
+
+### Changed
+
+- Improve reaction button popover menu
+  ([#449](https://github.com/giscus/giscus/pull/449)).
+
 ## 2022-03-19
 
 ### Added

--- a/components/Comment.tsx
+++ b/components/Comment.tsx
@@ -174,6 +174,7 @@ export default function Comment({
                   reactionGroups={comment.reactions}
                   subjectId={comment.id}
                   onReact={updateReactions}
+                  popoverPosition="top"
                 />
               ) : null}
             </div>

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -178,7 +178,7 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
 
         {shouldShowCommentBox && inputPosition === 'top' ? mainCommentBox : null}
 
-        <div className={`gsc-timeline ${inputPosition === 'top' ? 'input-top' : ''}`}>
+        <div className="gsc-timeline">
           {!data.isLoading
             ? data.frontComments.map((comment) => (
                 <Comment

--- a/components/ReactButtons.tsx
+++ b/components/ReactButtons.tsx
@@ -10,8 +10,9 @@ import { Trans, useGiscusTranslation } from '../lib/i18n';
 interface IReactButtonsProps {
   reactionGroups?: IReactionGroups;
   subjectId?: string;
-  onReact: (content: Reaction, promise: Promise<unknown>) => void;
   variant?: 'groupsOnly' | 'popoverOnly' | 'all';
+  popoverPosition?: 'top' | 'bottom';
+  onReact: (content: Reaction, promise: Promise<unknown>) => void;
   onDiscussionCreateRequest?: () => Promise<string>;
 }
 
@@ -49,6 +50,7 @@ export default function ReactButtons({
   subjectId,
   onReact,
   variant = 'all',
+  popoverPosition = 'bottom',
   onDiscussionCreateRequest,
 }: IReactButtonsProps) {
   const { t } = useGiscusTranslation();
@@ -126,15 +128,15 @@ export default function ReactButtons({
           <summary
             aria-label={t('addReactions')}
             className={`link-secondary gsc-reactions-button gsc-social-reaction-summary-item ${
-              variant === 'popoverOnly' ? 'popover-only' : 'popover'
+              variant === 'popoverOnly' ? 'popover-only' : ''
             }`}
           >
             <SmileyIcon size={16} />
           </summary>
           <div
-            className={`color-border-primary color-text-secondary color-bg-overlay gsc-reactions-popover ${
+            className={`color-border-primary color-text-secondary color-bg-overlay gsc-reactions-popover ${popoverPosition} ${
               isOpen ? ' open' : ''
-            } ${variant === 'popoverOnly' ? 'popover-only' : 'popover'}`}
+            } ${variant === 'popoverOnly' ? 'right' : 'left'}`}
           >
             <PopupInfo
               isLoading={isSubmitting}

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -65,6 +65,7 @@
   "pleaseWait": "Bitte warten…",
   "pickYourReaction": "Wähle deine Reaktion",
   "addTheReaction": "Reaktion {{reaction}} hinzufügen",
+  "removeTheReaction": "Reaktion {{reaction}} entfernen",
   "signInToAddYourReaction": "<a>Melde dich an</a> um deine Reaktion hinzuzufügen.",
   "youMustBeSignedInToAddReactions": "Du musst angemeldet sein um eine Reaktion hinzufügen zu können.",
   "peopleReactedWith": {

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -65,6 +65,7 @@
   "pleaseWait": "Please wait…",
   "pickYourReaction": "Pick your reaction",
   "addTheReaction": "Add {{reaction}} reaction",
+  "removeTheReaction": "Remove {{reaction}} reaction",
   "signInToAddYourReaction": "<a>Sign in</a> to add your reaction.",
   "youMustBeSignedInToAddReactions": "You must be signed in to add reactions.",
   "peopleReactedWith": {

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -65,6 +65,7 @@
   "pleaseWait": "Espere por favor…",
   "pickYourReaction": "Elige tu reacción",
   "addTheReaction": "Agregar reacción de {{reaction}}",
+  "removeTheReaction": "Eliminar reacción de {{reaction}}",
   "signInToAddYourReaction": "<a> Inicie sesión</a> para agregar su reacción.",
   "youMustBeSignedInToAddReactions": "Debes iniciar sesión para agregar reacciones.",
   "peopleReactedWith": {

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -65,6 +65,7 @@
   "pleaseWait": "Veuillez patienter…",
   "pickYourReaction": "Choisir une réaction",
   "addTheReaction": "Ajouter la réaction {{reaction}}",
+  "removeTheReaction": "Supprimer la réaction {{reaction}}",
   "signInToAddYourReaction": "<a>S'identifier</a> pour réagir.",
   "youMustBeSignedInToAddReactions": "Vous devez être identifié·e pour réagir.",
   "peopleReactedWith": {

--- a/locales/gsw/common.json
+++ b/locales/gsw/common.json
@@ -65,6 +65,7 @@
   "pleaseWait": "Bitte warten…",
   "pickYourReaction": "Wähle deine Reaktion",
   "addTheReaction": "Reaktion {{reaction}} hinzufügen",
+  "removeTheReaction": "Reaktion {{reaction}} entfernen",
   "signInToAddYourReaction": "<a>Melde dich an</a> um deine Reaktion hinzuzufügen.",
   "youMustBeSignedInToAddReactions": "Du musst angemeldet sein um eine Reaktion hinzufügen zu können.",
   "peopleReactedWith": {

--- a/locales/id/common.json
+++ b/locales/id/common.json
@@ -51,6 +51,7 @@
   "pleaseWait": "Mohon tunggu…",
   "pickYourReaction": "Pilih reaksi Anda",
   "addTheReaction": "Tambahkan reaksi {{reaction}}",
+  "removeTheReaction": "Batalkan reaksi {{reaction}}",
   "signInToAddYourReaction": "<a>Masuk</a> untuk menambahkan reaksi Anda.",
   "youMustBeSignedInToAddReactions": "Anda harus masuk untuk menambahkan reaksi.",
   "peopleReactedWith": {

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -65,6 +65,7 @@
   "pleaseWait": "Attendi…",
   "pickYourReaction": "Scegli la tua reazione",
   "addTheReaction": "Aggiungi reazione {{reaction}}",
+  "removeTheReaction": "Rimuovi la reazione {{reaction}}",
   "signInToAddYourReaction": "<a>Accedi</a> per aggiungere la tua reazione.",
   "youMustBeSignedInToAddReactions": "Devi accedere per aggiungere reazioni.",
   "peopleReactedWith": {

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -65,6 +65,7 @@
   "pleaseWait": "お待ちください…",
   "pickYourReaction": "リアクションを選択",
   "addTheReaction": "{{reaction}} をリアクションする",
+  "removeTheReaction": "{{reaction}} をリアクション元に戻す",
   "signInToAddYourReaction": "<a>ログイン</a>してリアクションする。",
   "youMustBeSignedInToAddReactions": "リアクションを追加するにはログインする必要があります。",
   "peopleReactedWith": {

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -65,6 +65,7 @@
   "pleaseWait": "잠시 기다리세요…",
   "pickYourReaction": "반응을 고르세요.",
   "addTheReaction": "{{reaction}} 반응 추가하기",
+  "removeTheReaction": "{{reaction}} 반응 제거하기",
   "signInToAddYourReaction": "<a>로그인</a>을 해서 반응을 남기세요.",
   "youMustBeSignedInToAddReactions": "반응을 남기기 위해선 로그인이 필요합니다.",
   "peopleReactedWith": {

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -79,6 +79,7 @@
   "pleaseWait": "Proszę czekać…",
   "pickYourReaction": "Wybierz reakcję",
   "addTheReaction": "Add {{reaction}} reaction",
+  "removeTheReaction": "Remove {{reaction}} reaction",
   "signInToAddYourReaction": "<a>Zaloguj się</a> aby dodać reakcję.",
   "youMustBeSignedInToAddReactions": "Musisz być zalogowany/a aby dodawać reakcje.",
   "peopleReactedWith": {

--- a/locales/ro/common.json
+++ b/locales/ro/common.json
@@ -72,6 +72,7 @@
   "pleaseWait": "Te rog așteaptă…",
   "pickYourReaction": "Alege reacția",
   "addTheReaction": "Add {{reaction}} reaction",
+  "removeTheReaction": "Remove {{reaction}} reaction",
   "signInToAddYourReaction": "<a>Logare</a> pentru a adăuga reacția",
   "youMustBeSignedInToAddReactions": "Trebuie să fii logat pentru a adăuga reacții.",
   "peopleReactedWith": {

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -79,6 +79,7 @@
   "pleaseWait": "Пожалуйста, подождите…",
   "pickYourReaction": "Выберите свой отклик",
   "addTheReaction": "Оставить {{reaction}} отклик",
+  "removeTheReaction": "Отменить {{reaction}} отклик",
   "signInToAddYourReaction": "<a>Войдите</a>, чтобы оставить свой отклик.",
   "youMustBeSignedInToAddReactions": "Вы должны авторизоваться, чтобы оставить отклик.",
   "peopleReactedWith": {

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -65,6 +65,7 @@
   "pleaseWait": "Lütfen bekleyin…",
   "pickYourReaction": "Tepki seçin",
   "addTheReaction": "{{reaction}} tepkisini ekle",
+  "removeTheReaction": "{{reaction}} tepkisini kaldır",
   "signInToAddYourReaction": "Tepki vermek için <a>giriş yap</a>.",
   "youMustBeSignedInToAddReactions": "Tepki eklemek için giriş yapmış olmalısın.",
   "peopleReactedWith": {

--- a/locales/vi/common.json
+++ b/locales/vi/common.json
@@ -65,6 +65,7 @@
   "pleaseWait": "Vui lòng đợi…",
   "pickYourReaction": "Chọn reaction của bạn",
   "addTheReaction": "Thêm {{reaction}} reaction",
+  "removeTheReaction": "Xóa {{reaction}} reaction",
   "signInToAddYourReaction": "<a>Đăng nhập</a> để thêm reaction của bạn.",
   "youMustBeSignedInToAddReactions": "Bạn phải đăng nhập để thêm reaction.",
   "peopleReactedWith": {

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -51,6 +51,7 @@
   "pleaseWait": "请稍候……",
   "pickYourReaction": "选择你的反应",
   "addTheReaction": "表示 {{reaction}}",
+  "removeTheReaction": "取消表示 {{reaction}}",
   "signInToAddYourReaction": "<a>登录</a>以添加反应。",
   "youMustBeSignedInToAddReactions": "你必须登录才能添加反应。",
   "peopleReactedWith": {

--- a/locales/zh-TW/common.json
+++ b/locales/zh-TW/common.json
@@ -51,6 +51,7 @@
   "pleaseWait": "請稍後……",
   "pickYourReaction": "挑選您的反應",
   "addTheReaction": "表示 {{reaction}}",
+  "removeTheReaction": "取消表示 {{reaction}}",
   "signInToAddYourReaction": "<a>登入</a>以送出反應。",
   "youMustBeSignedInToAddReactions": "您必須登入才能送出反應。",
   "peopleReactedWith": {

--- a/styles/base.css
+++ b/styles/base.css
@@ -398,42 +398,6 @@ img.emoji {
   background-color: var(--color-border-muted, var(--color-border-secondary));
 }
 
-.gsc-reactions-popover.open.popover::before {
-  position: absolute;
-  top: -16px;
-  left: 9px;
-  border: 8px solid transparent;
-  border-bottom-color: var(--color-border-default, var(--color-border-primary));
-  content: "";
-}
-
-.gsc-reactions-popover.open.popover::after {
-  position: absolute;
-  top: -15px;
-  left: 10px;
-  border: 7px solid transparent;
-  border-bottom: 8px solid var(--color-canvas-overlay, var(--color-bg-overlay));
-  content: "";
-}
-
-.gsc-reactions-popover.open.popover-only::before {
-  position: absolute;
-  top: -16px;
-  right: 9px;
-  border: 8px solid transparent;
-  border-bottom-color: var(--color-border-default, var(--color-border-primary));
-  content: "";
-}
-
-.gsc-reactions-popover.open.popover-only::after {
-  position: absolute;
-  top: -15px;
-  right: 10px;
-  border: 7px solid transparent;
-  border-bottom: 8px solid var(--color-canvas-overlay, var(--color-bg-overlay));
-  content: "";
-}
-
 .gsc-emoji-button:focus .gsc-emoji,
 .gsc-emoji-button:hover .gsc-emoji {
   @apply inline-block transition-transform;
@@ -448,10 +412,6 @@ img.emoji {
 
 .gsc-homepage-bg {
   background-color: var(--color-canvas-default, var(--color-bg-canvas));
-}
-
-.gsc-timeline.input-top {
-  @apply pb-12;
 }
 
 .gsc-timeline {
@@ -659,6 +619,54 @@ img.emoji {
   color: var(--color-accent-fg, var(--color-text-link));
 }
 
+.gsc-reactions-popover.open::before {
+  @apply absolute border-8 border-transparent border-solid;
+
+  content: "";
+}
+
+.gsc-reactions-popover.open::after {
+  @apply absolute border-[7px] border-transparent border-solid;
+
+  content: "";
+}
+
+.gsc-reactions-popover.open.bottom::before {
+  top: -16px;
+  border-bottom-color: var(--color-border-default, var(--color-border-primary));
+}
+
+.gsc-reactions-popover.open.bottom::after {
+  top: -15px;
+  border-bottom: 8px solid var(--color-canvas-overlay, var(--color-bg-overlay));
+}
+
+.gsc-reactions-popover.open.top::before {
+  bottom: -16px;
+  border-top-color: var(--color-border-default, var(--color-border-primary));
+}
+
+.gsc-reactions-popover.open.top::after {
+  bottom: -15px;
+  border-top: 8px solid var(--color-canvas-overlay, var(--color-bg-overlay));
+}
+
+.gsc-reactions-popover.open.left::before {
+  left: 9px;
+}
+
+.gsc-reactions-popover.open.left::after {
+  left: 10px;
+}
+
+.gsc-reactions-popover.open.right::before {
+  right: 9px;
+}
+
+.gsc-reactions-popover.open.right::after {
+  right: 10px;
+}
+
 .gsc-reactions-popover {
   /* stylelint-disable-next-line max-line-length */
   @apply ease-in-out duration-100 origin-center transform transition z-20 border rounded mt-[2px] absolute invisible scale-50 w-[146px];
@@ -668,8 +676,12 @@ img.emoji {
   @apply visible scale-100;
 }
 
-.gsc-reactions-popover.popover-only {
+.gsc-reactions-popover.right {
   @apply right-0;
+}
+
+.gsc-reactions-popover.top {
+  @apply bottom-8;
 }
 
 .gsc-emoji-button {

--- a/styles/base.css
+++ b/styles/base.css
@@ -136,7 +136,7 @@ a {
 }
 
 .BtnGroup-item:first-child:not(:only-child) {
-  @apply rounded-r-none rounded-l;
+  @apply rounded-l rounded-r-none;
 }
 
 .BtnGroup-item:last-child:not(:only-child) {
@@ -475,7 +475,7 @@ img.emoji {
 }
 
 .gsc-header {
-  @apply flex flex-auto items-center;
+  @apply flex items-center flex-auto;
 }
 
 .gsc-left-header {
@@ -537,7 +537,7 @@ img.emoji {
 }
 
 .gsc-comment-box {
-  @apply w-full text-sm mt-4;
+  @apply w-full mt-4 text-sm;
 }
 
 .gsc-comment-box:not(.gsc-comment-box-is-reply) {
@@ -640,7 +640,11 @@ img.emoji {
 }
 
 .gsc-reactions-button {
-  @apply px-[5px] py-[3px] mr-2 leading-[inherit] text-xs;
+  @apply px-[5px] py-[3px] mr-2 leading-[inherit] text-xs cursor-pointer;
+}
+
+.gsc-reactions-button::marker {
+  content: "";
 }
 
 .gsc-reactions-button:hover {


### PR DESCRIPTION
It now uses `<details>` and `<summary>` elements. It can be opened upwards and I made it so for the `Comment` component, making the extra bottom padding unnecessary.

Fixes #447.