### PR TITLE
Rename package to giscus.app and set version to 0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "giscus",
-  "version": "0.1.0",
+  "name": "giscus.app",
+  "version": "0.0.0",
   "private": false,
   "browserslist": [
     ">0.3%",


### PR DESCRIPTION
The `giscus` package name is reserved for the [web component](https://github.com/giscus/giscus-component).