### PR TITLE
Remove `<summary>` marker for reactions button on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ writing, this is a rolling-release project without any meaningful versioning
 whatsoever. Tags/releases may be created for the sole purpose of documenting
 major updates to the project.
 
+## 2022-04-10
+
+### Fixed
+
+- Remove `<summary>` marker for reactions button on Safari
+  ([#486](https://github.com/giscus/giscus/pull/486)).
+
 ## 2022-04-09
 
 ### Changed

--- a/client.ts
+++ b/client.ts
@@ -104,6 +104,7 @@
   style.textContent = `
   .giscus, .giscus-frame {
     width: 100%;
+    min-height: 150px;
   }
 
   .giscus-frame {

--- a/styles/base.css
+++ b/styles/base.css
@@ -405,7 +405,7 @@ img.emoji {
 }
 
 .gsc-loading-text {
-  @apply text-sm;
+  @apply text-sm whitespace-nowrap text-center w-full;
 }
 
 .gsc-tl-line {

--- a/styles/base.css
+++ b/styles/base.css
@@ -616,7 +616,12 @@ img.emoji {
 }
 
 .gsc-reactions-button {
-  @apply w-[26px] h-[26px] px-0 flex items-center justify-center leading-tight text-xs cursor-pointer;
+  @apply w-[26px] h-[26px] px-0 flex items-center justify-center leading-tight text-xs cursor-pointer list-none;
+}
+
+.gsc-reactions-button::before,
+.gsc-reactions-button::-webkit-details-marker {
+  display: none;
 }
 
 .gsc-reactions-button::marker {


### PR DESCRIPTION
Fixes #485.