### PR TITLE
Add support for mathematical expressions using MathJax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ writing, this is a rolling-release project without any meaningful versioning
 whatsoever. Tags/releases may be created for the sole purpose of documenting
 major updates to the project.
 
+## 2022-05-21
+
+### Added
+
+- Add support for mathematical expressions using MathJax
+  ([#548](https://github.com/giscus/giscus/pull/548)).
+
 ## 2022-05-20
 
 ### Added

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -47,6 +47,10 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
     emitData(message, origin);
   }, [data.discussion, data.viewer, emitMetadata, origin]);
 
+  useEffect(() => {
+    import('../lib/vendor/math-renderer-element');
+  }, []);
+
   const handleDiscussionCreateRequest = async () => {
     const id = await onDiscussionCreateRequest();
     // Force revalidate

--- a/lib/vendor/LICENSE
+++ b/lib/vendor/LICENSE
@@ -1,0 +1,4 @@
+Everything under this directory is provided as-is and NOT covered under the
+MIT License.
+
+I do not claim ownership of any files in this directory.

--- a/lib/vendor/math-renderer-element.ts
+++ b/lib/vendor/math-renderer-element.ts
@@ -1,0 +1,114 @@
+/*! THIS FILE IS NOT COVERED BY THE MIT LICENSE.
+ * Adapted from GitHub's client code (and its sourcemaps)
+ * provided to the browser when you load their website.
+ */
+
+import type MathJaxConfig from 'mathjax/es5/tex-chtml-full';
+
+declare global {
+  interface Window {
+    MathJax: MathJaxConfig;
+  }
+}
+
+const INLINE_DELIMITER = '$';
+const DISPLAY_DELIMITER = '$$';
+const STATIC_RESOURCE_ATTR = 'data-static-url';
+
+const purifyConfigs = {
+  ADD_ATTR: ['jax', 'unselectable', 'display'],
+  FORBID_TAGS: ['style', 'script', 'a'],
+  KEEP_CONTENT: true,
+  CUSTOM_ELEMENT_HANDLING: {
+    tagNameCheck: /^(TEX|mjx|MJX)/,
+    attributeNameCheck: /^(TEX|mjx|MJX)/,
+    allowCustomizedBuiltInElements: true,
+  },
+};
+
+let MathJax: null | MathJaxConfig = null;
+let DOMPurify: null | { default: typeof import('dompurify') } = null;
+
+async function configureMathJax({ staticURL }: { staticURL: string }) {
+  if (MathJax) {
+    return;
+  }
+
+  window.MathJax = {
+    ...(window.MathJax || {}),
+    tex: {
+      inlineMath: [[INLINE_DELIMITER, INLINE_DELIMITER]],
+      displayMath: [[DISPLAY_DELIMITER, DISPLAY_DELIMITER]],
+      packages: { '[-]': ['html', 'require', 'newcommand'] },
+    },
+    chtml: {
+      fontURL: `${staticURL}/fonts/mathjax`,
+    },
+    startup: {
+      typeset: false,
+    },
+    options: {
+      enableMenu: true,
+      renderActions: {
+        addMenu: [100000],
+      },
+    },
+  };
+
+  MathJax = await import('mathjax/es5/tex-chtml-full');
+  DOMPurify = await import('dompurify');
+}
+
+class MathRendererElement extends HTMLElement {
+  public staticURL = 'https://github.githubassets.com/static';
+
+  async connectedCallback() {
+    this.staticURL = this.getAttribute(STATIC_RESOURCE_ATTR) || this.staticURL;
+    await configureMathJax({ staticURL: this.staticURL });
+    requestAnimationFrame(() => this.typeset());
+  }
+
+  async typeset() {
+    if (!window.MathJax || !DOMPurify) {
+      return;
+    }
+
+    // insert latex into a shadow document to avoid potentially
+    // introducing xss vectors
+    const doc = document.implementation.createHTMLDocument('');
+
+    doc.open();
+    doc.write(`
+      <html>
+        <body>
+          ${this.firstChild?.textContent}
+        </body>
+      </html>
+    `);
+    doc.close();
+
+    // in-place typeset the content in the parallel document
+    await window.MathJax.typesetPromise([doc.body]);
+
+    const sanitized = DOMPurify?.default.sanitize(
+      doc.body.firstElementChild as Node,
+      purifyConfigs,
+    ) as string;
+    this.innerHTML = sanitized;
+
+    // If there isn't any content left after sanitizing, don't attempt to reset any nodes
+    if (sanitized) {
+      // reset the typesetRoot to the real document
+      const displayedMath = window.MathJax.startup.output.math;
+
+      if (displayedMath && displayedMath.typesetRoot) {
+        displayedMath.typesetRoot = this.firstChild;
+        window.MathJax.startup.output.document.menu.addMenu(displayedMath);
+      }
+    }
+  }
+}
+
+if (!customElements.get('math-renderer')) {
+  customElements.define('math-renderer', MathRendererElement);
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   },
   "dependencies": {
     "@primer/octicons-react": "^17.2.0",
+    "dompurify": "^2.3.8",
     "jsonwebtoken": "^8.5.1",
+    "mathjax": "^3.2.1",
     "next": "^12.1.6",
     "next-translate": "^1.4.0",
     "preact": "^10.7.2",
@@ -33,6 +35,7 @@
   "devDependencies": {
     "@next/bundle-analyzer": "^12.1.6",
     "@prefresh/next": "^1.5.2",
+    "@types/dompurify": "^2.3.3",
     "@types/jsonwebtoken": "^8.5.7",
     "@types/node": "^16.11.35",
     "@types/react": "^18.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,6 +227,13 @@
   resolved "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@types/dompurify@^2.3.3":
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.3.tgz#c24c92f698f77ed9cc9d9fa7888f90cf2bfaa23f"
+  integrity sha512-nnVQSgRVuZ/843oAfhA25eRSNzUFcBPk/LOiw5gm8mD9/X7CNcbRkQu/OsjCewO8+VIYfPxUnXvPEVGenw14+w==
+  dependencies:
+    "@types/trusted-types" "*"
+
 "@types/json-schema@^7.0.7":
   version "7.0.11"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz"
@@ -287,6 +294,11 @@
   version "0.16.2"
   resolved "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
+
+"@types/trusted-types@*":
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
+  integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
 "@typescript-eslint/eslint-plugin@^4.33.0":
   version "4.33.0"
@@ -1059,6 +1071,11 @@ domhandler@^4.2.0, domhandler@^4.3.1:
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
+
+dompurify@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz#224fe9ae57d7ebd9a1ae1ac18c1c1ca3f532226f"
+  integrity sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw==
 
 domutils@^2.8.0:
   version "2.8.0"
@@ -2216,6 +2233,11 @@ map-obj@^4.0.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
+
+mathjax@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/mathjax/-/mathjax-3.2.1.tgz#b74b0cec928322dff6a3c74a757c534e69916d25"
+  integrity sha512-blUch14trKnfQHjDjy1kdg5bN8jK0bdHbkerQBKCrZ3Anpb81zZ7xnj5J55vsqQoG+Irz3BHBDzRssjeehkzxg==
 
 mathml-tag-names@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
Fixes #165.

https://github.blog/2022-05-19-math-support-in-markdown/

https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions