### PR TITLE
Use MathJax 3.2.0 and fix a11y failing to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ major updates to the project.
   ([#548](https://github.com/giscus/giscus/pull/548)).
 - Add Tritanopia themes
   ([#549](https://github.com/giscus/giscus/pull/549)).
+- Use MathJax 3.2.0 and fix a11y failing to load
+  ([#550](https://github.com/giscus/giscus/pull/550)).
 
 ## 2022-05-20
 

--- a/lib/vendor/math-renderer-element.ts
+++ b/lib/vendor/math-renderer-element.ts
@@ -29,13 +29,38 @@ const purifyConfigs = {
 let MathJax: null | MathJaxConfig = null;
 let DOMPurify: null | { default: typeof import('dompurify') } = null;
 
+/**
+ * Get Speech-Rule-Engine files externally.
+ */
+function configureSRE() {
+  const script = document.getElementById('sre-config') || document.createElement('script');
+  script.id = 'sre-config';
+  script.setAttribute('type', 'text/x-sre-config');
+  script.textContent = JSON.stringify({
+    json: 'https://cdn.jsdelivr.net/npm/speech-rule-engine@3.3.3/lib/mathmaps/',
+    xpath: 'https://cdn.jsdelivr.net/gh/google/wicked-good-xpath@master/dist/wgxpath.install.js',
+  });
+  document.head.appendChild(script);
+}
+
 async function configureMathJax({ staticURL }: { staticURL: string }) {
   if (MathJax) {
     return;
   }
 
+  // Things like a11y and SVG rendering are still brittle and may break rendering.
+  // We don't have much control over them, so always clear the settings on load.
+  localStorage.removeItem('MathJax-Menu-Settings');
+
+  configureSRE();
+
   window.MathJax = {
     ...(window.MathJax || {}),
+    loader: {
+      paths: {
+        mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5',
+      },
+    },
     tex: {
       inlineMath: [[INLINE_DELIMITER, INLINE_DELIMITER]],
       displayMath: [[DISPLAY_DELIMITER, DISPLAY_DELIMITER]],

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@primer/octicons-react": "^17.2.0",
     "dompurify": "^2.3.8",
     "jsonwebtoken": "^8.5.1",
-    "mathjax": "^3.2.1",
+    "mathjax": "3.2.0",
     "next": "^12.1.6",
     "next-translate": "^1.4.0",
     "preact": "^10.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,10 +2234,10 @@ map-obj@^4.0.0:
   resolved "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-mathjax@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.npmjs.org/mathjax/-/mathjax-3.2.1.tgz#b74b0cec928322dff6a3c74a757c534e69916d25"
-  integrity sha512-blUch14trKnfQHjDjy1kdg5bN8jK0bdHbkerQBKCrZ3Anpb81zZ7xnj5J55vsqQoG+Irz3BHBDzRssjeehkzxg==
+mathjax@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/mathjax/-/mathjax-3.2.0.tgz#ea7c317f8c81776ecfc83b294fc313046bf7f726"
+  integrity sha512-PL+rdYRK4Wxif+SQ94zP/L0sv6/oW/1WdQiIx0Jvn9FZaU5W9E6nlIv8liYAXBNPL2Fw/i+o/mZ1212eSzn0Cw==
 
 mathml-tag-names@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
Interacting with MathJax menu and activating the a11y features broke the rendering because the files aren't included in the bundle. The same also happens with SVG rendering. This works around that issue by loading the MathJax files from CDN and clearing the settings on load.