### PR TITLE
Prevent input zoom-in on iPhone Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ major updates to the project.
 
 - Prevent duplicated discussion creation
   ([#623](https://github.com/giscus/giscus/pull/623)).
+- Prevent input zoom on iPhone Safari
+  ([#625](https://github.com/giscus/giscus/pull/625)).
 
 ## 2022-07-23
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -111,6 +111,14 @@ a {
   box-shadow: var(--color-primer-shadow-focus, var(--color-state-focus-shadow));
 }
 
+@supports (-webkit-touch-callout: none) {
+  .form-control,
+  .form-select {
+    /* Ensures inputs don't zoom on mobile iPhone but are normal on iPad */
+    @apply text-base md:text-sm;
+  }
+}
+
 .input-contrast {
   background-color: var(--color-canvas-inset, var(--color-input-contrast-bg));
 }


### PR DESCRIPTION
Fixes #613.

Ref: https://github.com/primer/css/pull/1147