### PR TITLE
Improve zh-TW localization

### DIFF
--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -98,6 +98,6 @@ giscus 載入時，會使用 [GitHub Discussions 搜尋 API][search-api] 根據�
 - [简体中文](README.zh-CN.md)
 - [繁體中文](README.zh-TW.md)
 
-[![威力本源 Vercel](public/powered-by-vercel.svg)][vercel]
+[![由 Vercel 技術支援](public/powered-by-vercel.svg)][vercel]
 
 [vercel]: https://vercel.com/?utm_source=giscus&utm_campaign=oss

--- a/locales/zh-TW/common.json
+++ b/locales/zh-TW/common.json
@@ -21,7 +21,7 @@
   "loading": "載入中",
   "loadingComments": "正在載入留言……",
   "loadingPreview": "正在載入預覽……",
-  "poweredBy": "– 威力本源 <a>giscus</a>",
+  "poweredBy": "– 由 <a>giscus</a> 技術支援",
   "oldest": "最舊",
   "newest": "最新",
   "showPreviousReplies": {


### PR DESCRIPTION
Fixed wrong localization of "Powered by", had been wrongly translated as something like "origin energy"