### PR TITLE
Improve german translation

### DIFF
--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -4,7 +4,7 @@
     "one": "{{count}} Reaktion",
     "other": "{{count}} Reaktionen"
   },
-  "comment": "Kommentar",
+  "comment": "Kommentieren",
   "comments": {
     "0": "{{count}} Kommentare",
     "one": "{{count}} Kommentar",
@@ -22,9 +22,9 @@
     "other": "{{count}} Upvotes"
   },
   "hiddenItems": {
-    "0": "{{count}} versteckte Items",
-    "one": "{{count}} verstecktes Item",
-    "other": "{{count}} versteckte Items"
+    "0": "{{count}} versteckte Elemente",
+    "one": "{{count}} verstecktes Element",
+    "other": "{{count}} versteckte Elemente"
   },
   "genericError": "Ein Fehler ist aufgetreten: {{message}}",
   "loadMore": "Lade mehr",


### PR DESCRIPTION
When I integrated Giscus into my german website, I noticed a few things in the translation.

The button to submit a comment was named "Kommentar" which is a noun in german. But we need the verb instead of the noun in the button for correct language. In english, the word "comment" is the same but distinguished by context. In german, we have two different words for that.

"a comment" -> "Kommentar"
"to comment" -> "Kommentieren"

Another thing was "versteckte Items". "Items" is still an english word. The german word for "Items" is "Elemente".

I fixed these things here in my pull request