### PR TITLE
Basic basepath support

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -1,7 +1,6 @@
 (function () {
   const GISCUS_SESSION_KEY = 'giscus-session';
   const script = document.currentScript as HTMLScriptElement;
-  const giscusOrigin = new URL(script.src).origin;
 
   function formatError(message: string) {
     return `[giscus] An error occurred. Error message: "${message}".`;
@@ -52,6 +51,10 @@
   params.strict = attributes.strict || '0';
   params.description = getMetaContent('description', true);
   params.backLink = getMetaContent('giscus:backlink') || cleanedLocation;
+  params.basePath = attributes.basePath || '';
+
+  const giscusOrigin = attributes.giscusOrigin || new URL(script.src).origin;
+
 
   switch (attributes.mapping) {
     case 'url':
@@ -71,10 +74,10 @@
       break;
     case 'pathname':
     default:
-      params.term =
-        location.pathname.length < 2
+      const localPath = location.pathname.replace(params.basePath, '');
+      params.term = localPath.length < 2
           ? 'index'
-          : location.pathname.substring(1).replace(/\.\w+$/, '');
+          : localPath.substring(1).replace(/\.\w+$/, '');
       break;
   }
 

--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -43,6 +43,7 @@ interface IConfig {
   strict: boolean;
   useCategory: boolean;
   lazyLoad: boolean;
+  basePath: string;
 }
 
 const mappingOptions: Array<{
@@ -111,6 +112,7 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
     strict: false,
     useCategory: true,
     lazyLoad: false,
+    basePath: '',
   });
   const [error, setError] = useState(false);
   const [categories, setCategories] = useState<ICategory[]>([]);
@@ -316,6 +318,22 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
             ) : null}
           </div>
         ))}
+      </fieldset>
+      <p>{t('defineBasePath')}</p>
+      <fieldset>
+        <label htmlFor="basePath" className="block font-semibold">
+          {t('basePathLabel')}
+        </label>
+        <input
+          id="basePath"
+          value={config.basePath}
+          onChange={(event) =>
+            setConfig((current) => ({ ...current, basePath: event.target.value }))
+          }
+          type="text"
+          className="form-control min-w-[75%] placeholder-gray-500 my-2 rounded-md border px-[12px] py-[5px] sm:min-w-[50%]"
+          placeholder={t('/my/custom/basepath')}
+        />
       </fieldset>
       <div className="form-checkbox">
         <input
@@ -577,6 +595,13 @@ export default function Configuration({ directConfig, onDirectConfigChange }: IC
           <span className="pl-c1">data-mapping</span>={'"'}
           <span className="pl-s">{config.mapping}</span>
           {'"\n        '}
+          {config.basePath !== '' ? (
+            <>
+              <span className="pl-c1">data-base-path</span>={'"'}
+              <span className="pl-s">{config.basePath || ''}</span>
+              {'"\n        '}
+            </>
+          ) : null}
           {['specific', 'number'].includes(config.mapping) ? (
             <>
               <span className="pl-c1">data-term</span>={'"'}

--- a/locales/en/config.json
+++ b/locales/en/config.json
@@ -34,6 +34,10 @@
   "useStrictTitleMatching": "Use strict title matching",
   "avoidMismatches": "Avoid mismatches due to GitHub's fuzzy searching method when there are multiple discussions with similar titles. See <a>the documentation</a> for more details.",
 
+  "defineBasePath": "Define base path (pathname mapping only)",
+  "basePathLabel": "Basepath",
+  "/my/custom/basepath": "/my/custom/basepath",
+
   "discussionCategory": "Discussion Category",
   "chooseTheDiscussionCategory": "Choose the discussion category where new discussions will be created.",
   "categoryIsNotSupported": "This feature is not supported if you use the <strong>specific discussion number</strong> mapping.",

--- a/locales/fr/config.json
+++ b/locales/fr/config.json
@@ -34,6 +34,10 @@
   "useStrictTitleMatching": "Utiliser une correspondance de titre stricte",
   "avoidMismatches": "Évitez les correspondances incorrectes en raison de la méthode de recherche floue de GitHub lorsqu'il existe plusieurs discussions avec des titres similaires. Consultez la <a>documentation</a> pour plus de détails.",
 
+  "defineBasePath": "Définition du répertoire de base",
+  "basePathLabel": "Répertoire de base",
+  "/my/custom/basepath": "/mon/repertoire/de/base",
+
   "discussionCategory": "Catégorie de la Discussion",
   "chooseTheDiscussionCategory": "Choisir la catégorie de discussion assciée aux nouvelles discussions crées par giscus.",
   "categoryIsNotSupported": "Cette fonctionnalité n'est pas disponible si vous avez opté pour le mappage selon un <strong>numéro de discussion spécifique</strong>.",


### PR DESCRIPTION
A very simple PR to add support for a basepath of the website, to be removed from pathname before searching/creating GitHub discussion. It adds a `data-base-path` parameter.

For a jekyll site, it can be simply set to site.baseurl:
```
       data-base-path="{{ site.baseurl }}"
```

For development purpose, I have also added the ability to override giscusOrigin to be able to use a custom client.js with the giscus server. I guess this could be useful to other contributors.