### PR TITLE
Fix LAUGH reaction emoji

### DIFF
--- a/lib/reactions.ts
+++ b/lib/reactions.ts
@@ -3,7 +3,7 @@ import { IComment, IGiscussion, IReactionGroups, IReply } from './types/adapter'
 export const Reactions = {
   THUMBS_UP: '👍',
   THUMBS_DOWN: '👎',
-  LAUGH: '😆',
+  LAUGH: '😄',
   HOORAY: '🎉',
   CONFUSED: '😕',
   HEART: '❤️',


### PR DESCRIPTION
The link to the image of the LAUGH reaction on GitHub is <https://github.githubassets.com/images/icons/emoji/unicode/1f604.png>.

The emoji of Unicode 1f604 is "😄" instead of "😆", according to <https://www.unicode.org/charts/nameslist/n_1F600.html>.

BTW, when this PR body is displayed on GitHub, you can see that "😄" is the one that appears the same as the reaction on GitHub.