### PR TITLE
Improve zh-TW localization

### DIFF
--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # [giscus][giscus]
 
-由 [GitHub Discussions][discussions] 驅動的留言系统。讓訪客借助 GitHub 在你的網站上留言和留下反應吧！本專案很大一部份是受 [utterances][utterances] 啟發。
+由 [GitHub Discussions][discussions] 驅動的留言系統。讓訪客借助 GitHub 在你的網站上留言和留下反應吧！本專案很大一部份是受 [utterances][utterances] 啟發。
 
 - [開放原始碼][repo]。🌏
 - 無追蹤，無廣告，永久免費。📡 🚫
@@ -44,7 +44,7 @@ giscus 載入時，會使用 [GitHub Discussions 搜尋 API][search-api] 根據�
 
 ## 轉移
 
-如果你曾經使用過其它利用 GitHub Issue 的留言系统（如 [utterances][utterances]、[gitalk][gitalk]），你可以[把已有的 issue 轉換成 discussion][convert]。轉換後，只要確保 discussion 標題與頁面的對應關係正確，giscus 就會自動使用這些 discussion。
+如果你曾經使用過其它利用 GitHub Issue 的留言系統（如 [utterances][utterances]、[gitalk][gitalk]），你可以[把已有的 issue 轉換成 discussion][convert]。轉換後，只要確保 discussion 標題與頁面的對應關係正確，giscus 就會自動使用這些 discussion。
 
 ## 正使用 giscus 的網站
 

--- a/locales/zh-TW/config.json
+++ b/locales/zh-TW/config.json
@@ -14,7 +14,7 @@
   "repository": "儲存庫",
   "chooseTheRepository": "選擇 giscus 要連結的儲存庫。請確保：",
   "theRepositoryIsPublic": "<strong>此儲存庫是<a>公開的</a></strong>，否則訪客將無法查看 discussion。",
-  "theGiscusAppIsInstalled": "已安装 <strong><a>giscus</a> 應用程式</strong>，否則訪客將無法留言或回應。",
+  "theGiscusAppIsInstalled": "已安裝 <strong><a>giscus</a> 應用程式</strong>，否則訪客將無法留言或回應。",
   "theDiscussionsFeatureIsTurnedOn": "你要連結的儲存庫已<a>啟用 <strong>Discussions</strong> 功能</a>。",
   "repositoryLabel": "儲存庫：",
   "myusername/myrepo": "myusername/myrepo",
@@ -83,7 +83,7 @@
 
   "enableGiscus": "啟用 giscus",
   "addTheFollowingScriptTag": "在你想放置留言區的位置加上下列的 <code><script></code> 標籤。但如果已經存在使用 <code>giscus</code> class 的元素，留言區會出現在那邊。",
-  "youHaveNotConfiguredRepositoryCategory": "您尚未配置<arepo>儲存庫</arepo>和/或<acategory>分類</acategory>。 在您填寫這些字段之前，不會顯示這些字段的值。",
+  "youHaveNotConfiguredRepositoryCategory": "您尚未配置<arepo>儲存庫</arepo>和/或<acategory>分類</acategory>。 在您填寫這些欄位之前，不會顯示這些欄位的值。",
   "copy": "複製",
 
   "[enterRepoHere]": "[在此輸入儲存庫名稱]",


### PR DESCRIPTION
Wrong localization between Simplified Chinese and Traditional Chinese.

Fixed wrong localization:
- "system" should be "統" instead of "统"
- "installed" should be "裝" instead of "装"
- "fields" should be "欄位" instead of "字段"