### PR TITLE
Fix french translation for "newest"

### DIFF
--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -33,7 +33,7 @@
   "loadingPreview": "Chargement de l'aperçu…",
   "poweredBy": "– propulsé par <a>giscus</a>",
   "oldest": "Ancien",
-  "newest": "Dernier",
+  "newest": "Récent",
   "showPreviousReplies": {
     "0": "Afficher {{count}} réponse précédénte",
     "one": "Afficher {{count}} réponse précédénte",


### PR DESCRIPTION
"Dernier" means "the last one", while "Récent" means... "recent"