### PR TITLE
Improve German translation

### DIFF
--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -56,7 +56,7 @@
   "writeAComment": "Schreibe einen Kommentar",
   "signInToComment": "Anmelden zum Kommentieren",
   "stylingWithMarkdownIsSupported": "Stylen mit Markdown ist unterstützt",
-  "signOut": "Austragen",
+  "signOut": "Abmelden",
   "cancel": "Abbrechen",
   "signInWithGitHub": "Mit GitHub anmelden",
   "writeAReply": "Schreibe eine Antwort",


### PR DESCRIPTION
"Abmelden" is a better translation here. "Austragen" is what Google translate suggests, but "Austragen" is rather used when you unsubscribe from a newsletter. "Abmelden" means "sign out", which is meant here.