### PR TITLE
Make Comment button a verb instead of a noun in Spanish

### DIFF
--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -4,7 +4,7 @@
     "one": "{{count}} reacción",
     "other": "{{count}} reacciones"
   },
-  "comment": "Comentario",
+  "comment": "Comentar",
   "comments": {
     "0": "{{count}} comentarios",
     "one": "{{count}} comentario",


### PR DESCRIPTION
Fix https://github.com/giscus/giscus/issues/951