### PR TITLE
fix reply text display

### DIFF
--- a/components/CommentBox.tsx
+++ b/components/CommentBox.tsx
@@ -40,6 +40,7 @@ export default function CommentBox({
   const textarea = useRef<HTMLTextAreaElement>(null);
   const loginUrl = getLoginUrl(origin);
   const isReply = !!replyToId;
+  const placeHolderText = isReply ? t('writeAReply') : t('writeAComment');
 
   useEffect(() => {
     if (isPreview && input !== lastInput) {
@@ -192,7 +193,7 @@ export default function CommentBox({
               className={`form-control input-contrast gsc-comment-box-textarea ${
                 isFixedWidth ? 'gsc-is-fixed-width' : ''
               }`}
-              placeholder={token ? t('writeAComment') : t('signInToComment')}
+              placeholder={token ? placeHolderText : t('signInToComment')}
               onChange={handleTextAreaChange}
               value={input}
               disabled={!token || isSubmitting}


### PR DESCRIPTION
before

<img width="748" alt="截屏2023-05-09 00 06 12" src="https://user-images.githubusercontent.com/93363751/236874902-7ffef296-c3ca-4ac3-8f33-10eca69ea9ba.png">

after

<img width="745" alt="截屏2023-05-09 00 06 33" src="https://user-images.githubusercontent.com/93363751/236874950-8d212c08-aa7f-4265-aa3c-fe18f6815f88.png">
