### PR TITLE
Change i18n.json to i18n.js

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ localization! Follow these steps to add a new localization:
    - `dateFormatters`, `shortDateFormatters`, `shortDateYearFormatters`, and
      `relativeTimeFormatters`: include new objects with your language code,
      following the existing languages.
-6. Edit [`i18n.json`][i18n-json] and include your language.
+6. Edit [`i18n.js`][i18n-js] and include your language.
 7. In all of the aforementioned files, make sure that the language list is
    sorted by the language code.
 8. [Create a PR][pr] with your localization updates.
@@ -100,4 +100,4 @@ localization! Follow these steps to add a new localization:
 [language-codes]: https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/languages_and_scripts.html
 [plural-rules]: https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/language_plural_rules.html
 [i18n-tsx]: lib/i18n.tsx
-[i18n-json]: i18n.json
+[i18n-js]: i18n.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,12 @@ localization! Follow these steps to add a new localization:
    [plural rules][plural-rules] for translation keys with an object as the value
    (e.g. those that require `{{ count }}`).
 4. Copy one of the README files and name it `README.[code].md`, e.g.
-   `README.id.md` and translate the content. Add your language to the bottom of
-   the new README and all the existing READMEs.
+   `README.id.md` and translate the content. Add your language to the new README
+   and all the existing READMEs, ordered by the language code.
 5. Edit [`i18n.tsx`][i18n-tsx] and update the following variables:
    - `availableLanguages`: include your language code and name.
+   - `rtlLanguages`: include your language code if it is a right-to-left
+     language.
    - `dateFormatters`, `shortDateFormatters`, `shortDateYearFormatters`, and
      `relativeTimeFormatters`: include new objects with your language code,
      following the existing languages.


### PR DESCRIPTION
It seems that `i18n.json` has been replaced in favor of `i18n.js` in commit 11a9d85110b2f7c05ac9fb1453c6172ea068c7d2. This PR changes the mention on `CONTRIBUTING.md`.