### PR TITLE
feat: support mapping on custom meta tag

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -69,6 +69,8 @@
     case 'number':
       params.number = attributes.term as string;
       break;
+    case 'custom-meta':
+      params.term = getMetaContent(attributes['mapping-custom-meta'])
     case 'pathname':
     default:
       params.term =


### PR DESCRIPTION
This introduces support for specifying a custom meta tag to get the discussion title from, because in some cases none of the options available is suitable.