### PR TITLE
Fix typo in color scheme key config.json in ko locales

### DIFF
--- a/locales/ko/config.json
+++ b/locales/ko/config.json
@@ -68,7 +68,7 @@
   "theme=dark": "GitHub Dark",
   "theme=dark_high_contrast": "GitHub Dark High Contrast",
   "theme=dark_protanopia": "GitHub Dark Protanopia & Deuteranopia",
-  "theme=dark_ptrianopia": "GitHub Dark Tritanopia",
+  "theme=dark_tritanopia": "GitHub Dark Tritanopia",
   "theme=dark_dimmed": "GitHub Dark Dimmed",
   "theme=preferred_color_scheme": "Preferred color scheme",
   "theme=transparent_dark": "Transparent Dark",


### PR DESCRIPTION
There is an error in korean demo page like attached image. It is caused by a typo error in config.json.
<img width="627" alt="image" src="https://github.com/giscus/giscus/assets/17683473/accd74ca-a45d-459c-b253-5c948156e137">
