### PR TITLE
Add CORS support to widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ writing, this is a rolling-release project without any meaningful versioning
 whatsoever. Tags/releases may be created for the sole purpose of documenting
 major updates to the project.
 
+## 2024-02-11
+
+### Added
+
+- Add Cross-Origin Resource Policy support
+  ([#1309](https://github.com/giscus/giscus/pull/1309)).
+
 ## 2024-02-10
 
 ### Added

--- a/pages/widget.tsx
+++ b/pages/widget.tsx
@@ -37,6 +37,9 @@ export async function getServerSideProps({ query, res }: GetServerSidePropsConte
 
   const repoConfig = await getRepoConfig(repo, token);
 
+  // Opt into CORP. See: https://web.dev/articles/coop-coep
+  res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+
   if (!assertOrigin(originHost, repoConfig)) {
     res.setHeader('Content-Security-Policy', `frame-ancestors 'none';`);
     res.setHeader('X-Frame-Options', 'DENY');


### PR DESCRIPTION
The widget doesn't set the CORP header, so comments can't load if I turn on COOP or COEP if I want to use stuff like SharedArrayBuffer. Turning on CORP should fix this (although I'm not sure if we have to mark a component iframe as crossorigin).