### PR TITLE
Fixed production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "format:fix": "prettier --write ."
   },
   "dependencies": {
+    "@next/bundle-analyzer": "^12.3.4",
     "@primer/octicons-react": "^19.9.0",
     "dompurify": "^3.0.11",
     "jsonwebtoken": "^9.0.2",
@@ -29,6 +30,7 @@
     "next": "^12.3.4",
     "next-plugin-preact": "^3.0.7",
     "next-translate": "^2.6.2",
+    "next-translate-plugin": "^2.6.2",
     "preact": "^10.20.1",
     "preact-render-to-string": "^6.4.1",
     "react": "npm:@preact/compat",
@@ -37,7 +39,6 @@
     "swr": "^2.2.5"
   },
   "devDependencies": {
-    "@next/bundle-analyzer": "^12.3.4",
     "@types/dompurify": "^3.0.5",
     "@types/node": "^18.16.9",
     "@types/react": "^18.0.9",
@@ -50,7 +51,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "google-closure-compiler": "^20240317.0.0",
-    "next-translate-plugin": "^2.6.2",
     "postcss": "^8.4.38",
     "postcss-cli": "^11.0.0",
     "postcss-import": "^16.1.0",


### PR DESCRIPTION
The node modules `@next/bundle-analyzer` and `next-translate-plugin` are required at runtime but defined as `devDependencies` in `package.json`.
So when installing production modules only, giscus will not start.

Steps to reproduce:

1. `yarn install`
2. `yarn build`
3. `yarn start` - working
4. `rm -r node_modules`
5. `yarn install --production`
6. `yarn start` - not working since `@next/bundle-analyzer` and `next-translate-plugin` missing