### PR TITLE
Use `giscus:description` `<meta>` tag to override `og:description` if necessary

### DIFF
--- a/ADVANCED-USAGE.md
+++ b/ADVANCED-USAGE.md
@@ -200,7 +200,7 @@ web page:
   >
   <meta
     name="giscus:description"
-    content="Let visitors leave comments and reactions on your website via GitHub!"
+    content="Please click the link above to see the post."
   >
   <!-- ... -->
 </head>

--- a/ADVANCED-USAGE.md
+++ b/ADVANCED-USAGE.md
@@ -182,6 +182,35 @@ https://bit.ly/RickRolled instead of your web page's URL. This can be useful if
 you want to use short links for your web pages (e.g. to avoid expired links if
 you change your website's URL structure or domain).
 
+### `giscus:description`
+
+If the page that embeds giscus has a `<meta>` tag with a
+`name="giscus:description"` attribute, the element will take the place of
+`<meta name="og:description" content="...">`. When creating a discussion, the
+discussion will includes that instead of the content of
+`<meta name="og:description">`. For example, with the following element in your
+web page:
+
+```html
+<head>
+  <!-- ... -->
+  <meta
+    name="og:description"
+    content="A comment system powered by GitHub Discussions."
+  >
+  <meta
+    name="giscus:description"
+    content="Let visitors leave comments and reactions on your website via GitHub!"
+  >
+  <!-- ... -->
+</head>
+```
+
+When giscus creates a new discussion, the discussion body will contain
+`Let visitors leave comments and reactions on your website via GitHub!` instead
+of `A comment system powered by GitHub Discussions.`. This can be useful if the
+page's `og:description` is volatile.
+
 ## giscus-to-parent `message` events
 
 There are `message` events emitted by giscus to the parent `window` using

--- a/client.ts
+++ b/client.ts
@@ -50,7 +50,7 @@
   params.category = attributes.category || '';
   params.categoryId = attributes.categoryId as string;
   params.strict = attributes.strict || '0';
-  params.description = getMetaContent('description', true);
+  params.description = getMetaContent('giscus:description') || getMetaContent('description', true);
   params.backLink = getMetaContent('giscus:backlink') || cleanedLocation;
 
   switch (attributes.mapping) {


### PR DESCRIPTION
close #1405