### PR TITLE
Fix :octocat: not showing in zh-TW readme

### DIFF
--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -4,7 +4,7 @@
 
 - [開放原始碼][repo]。🌏
 - 無追蹤，無廣告，永久免費。📡 🚫
-- 無需資料庫。全部資料均儲存在 GitHub Discussions 中。:octocat:
+- 無需資料庫。全部資料均儲存在 GitHub Discussions 中。 :octocat:
 - 支援[自訂佈景主題][creating-custom-themes]！🌗
 - 支援[多語言][multiple-languages]。🌐
 - [高度彈性][advanced-usage]。🔧


### PR DESCRIPTION
`:octocat` is not showing in https://github.com/giscus/giscus/blob/main/README.zh-TW.md

<img width="1355" alt="圖片" src="https://github.com/user-attachments/assets/381a29f9-f8ac-408b-9dba-101c36e3336e">
