### PR TITLE
Use `NEXT_PUBLIC_DEMO_REPO` to fetch token for rendering markdown on the homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,12 @@ major updates to the project.
 
 - Ensure links and link-like buttons are underlined
   ([#1586](https://github.com/giscus/giscus/pull/1586)).
+
 - Set `dir="auto"` on the comment `textarea`
   ([#1590](https://github.com/giscus/giscus/pull/1590)).
+
+- Use `NEXT_PUBLIC_DEMO_REPO` to fetch token for rendering markdown on the
+  homepage ([#1591](https://github.com/giscus/giscus/pull/1591)).
 
 
 ## 2024-11-28

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,9 +32,9 @@ export async function getStaticProps({ locale }: GetStaticPropsContext) {
 
   contents[1] = `${afterConfig}\n## ${t('tryItOut')} 👇👇👇\n`;
 
-  const token = await getAppAccessToken('giscus/giscus').catch(() => '');
+  const token = await getAppAccessToken(env.demo_repo).catch(() => '');
   const [contentBefore, contentAfter] = await Promise.all(
-    contents.map((section) => renderMarkdown(section, token, 'giscus/giscus')),
+    contents.map((section) => renderMarkdown(section, token, env.demo_repo)),
   );
 
   const comment: IComment = {


### PR DESCRIPTION
Probably fixes #1368.