### PR TITLE
Update Catppuccin themes

### DIFF
--- a/styles/themes/catppuccin_frappe.css
+++ b/styles/themes/catppuccin_frappe.css
@@ -1,23 +1,24 @@
 main {
-  --color-prettylights-syntax-comment: #838ba7;
+  --color-prettylights-syntax-comment: #949cbb;
   --color-prettylights-syntax-constant: #8caaee;
+  --color-prettylights-syntax-constant-other-reference-link: #8caaee;
   --color-prettylights-syntax-entity: #8caaee;
   --color-prettylights-syntax-storage-modifier-import: #ef9f76;
-  --color-prettylights-syntax-entity-tag: #81c8be;
-  --color-prettylights-syntax-keyword: #f4b8e4;
+  --color-prettylights-syntax-entity-tag: #8caaee;
+  --color-prettylights-syntax-keyword: #ca9ee6;
   --color-prettylights-syntax-string: #a6d189;
   --color-prettylights-syntax-variable: #ef9f76;
   --color-prettylights-syntax-invalid-illegal-text: #e78284;
-  --color-prettylights-syntax-invalid-illegal-bg: rgb(231 130 132 / 15%);
-  --color-prettylights-syntax-markup-heading: #81c8be;
+  --color-prettylights-syntax-invalid-illegal-bg: rgba(231, 130, 132, 0.15);
+  --color-prettylights-syntax-markup-heading: #e78284;
   --color-prettylights-syntax-markup-italic: #e5c890;
   --color-prettylights-syntax-markup-bold: #e5c890;
   --color-prettylights-syntax-markup-deleted-text: #c6d0f5;
-  --color-prettylights-syntax-markup-deleted-bg: rgb(231 130 132 / 40%);
+  --color-prettylights-syntax-markup-deleted-bg: rgba(231, 130, 132, 0.4);
   --color-prettylights-syntax-markup-inserted-text: #c6d0f5;
-  --color-prettylights-syntax-markup-inserted-bg: rgb(166 209 137 / 40%);
+  --color-prettylights-syntax-markup-inserted-bg: rgba(166, 209, 137, 0.4);
   --color-prettylights-syntax-markup-changed-text: #c6d0f5;
-  --color-prettylights-syntax-markup-changed-bg: rgb(229 200 144 / 40%);
+  --color-prettylights-syntax-markup-changed-bg: rgba(229, 200, 144, 0.4);
   --color-prettylights-syntax-markup-ignored-text: #c6d0f5;
   --color-btn-text: #c6d0f5;
   --color-btn-bg: #414559;
@@ -40,7 +41,7 @@ main {
   --color-btn-primary-selected-bg: #c2dfae;
   --color-btn-primary-selected-shadow: 0 0 transparent;
   --color-btn-primary-disabled-text: #232634;
-  --color-btn-primary-disabled-bg: rgb(166 209 137 / 40%);
+  --color-btn-primary-disabled-bg: rgba(166, 209, 137, 0.4);
   --color-btn-primary-disabled-border: transparent;
   --color-action-list-item-default-hover-bg: #51576d;
   --color-segmented-control-bg: #626880;
@@ -55,29 +56,27 @@ main {
   --color-canvas-subtle: #292c3c;
   --color-border-default: #51576d;
   --color-border-muted: #414559;
-  --color-neutral-muted: rgb(115 121 148 / 20%);
+  --color-neutral-muted: rgba(115, 121, 148, 0.2);
   --color-accent-fg: #ca9ee6;
   --color-accent-emphasis: #ca9ee6;
-  --color-accent-muted: rgb(202 158 230 / 40%);
-  --color-accent-subtle: rgb(202 158 230 / 15%);
+  --color-accent-muted: rgba(202, 158, 230, 0.4);
+  --color-accent-subtle: rgba(202, 158, 230, 0.15);
   --color-success-fg: #a6d189;
   --color-attention-fg: #ef9f76;
   --color-attention-muted: #ca9ee6;
-  --color-attention-subtle: rgb(202 158 230 / 15%);
+  --color-attention-subtle: rgba(202, 158, 230, 0.15);
   --color-danger-fg: #e78284;
-  --color-danger-muted: rgb(231 130 132 / 40%);
-  --color-danger-subtle: rgb(231 130 132 / 20%);
+  --color-danger-muted: rgba(231, 130, 132, 0.4);
+  --color-danger-subtle: rgba(231, 130, 132, 0.2);
   --color-primer-shadow-inset: 0 0 transparent;
   --color-scale-gray-7: #51576d;
   --color-scale-blue-8: #6089e7;
   --color-social-reaction-bg-hover: var(--color-scale-gray-7);
   --color-social-reaction-bg-reacted-hover: var(--color-scale-blue-8);
 }
-
 main .gsc-comment-box-textarea::placeholder {
   color: #a5adce;
 }
-
 main .gsc-loading-image {
   background-image: url("https://giscus.catppuccin.com/assets/loading.gif");
 }

--- a/styles/themes/catppuccin_latte.css
+++ b/styles/themes/catppuccin_latte.css
@@ -1,23 +1,24 @@
 main {
-  --color-prettylights-syntax-comment: #8c8fa1;
+  --color-prettylights-syntax-comment: #7c7f93;
   --color-prettylights-syntax-constant: #1e66f5;
+  --color-prettylights-syntax-constant-other-reference-link: #1e66f5;
   --color-prettylights-syntax-entity: #1e66f5;
   --color-prettylights-syntax-storage-modifier-import: #fe640b;
-  --color-prettylights-syntax-entity-tag: #179299;
-  --color-prettylights-syntax-keyword: #ea76cb;
+  --color-prettylights-syntax-entity-tag: #1e66f5;
+  --color-prettylights-syntax-keyword: #8839ef;
   --color-prettylights-syntax-string: #40a02b;
   --color-prettylights-syntax-variable: #fe640b;
   --color-prettylights-syntax-invalid-illegal-text: #d20f39;
-  --color-prettylights-syntax-invalid-illegal-bg: rgb(210 15 57 / 15%);
-  --color-prettylights-syntax-markup-heading: #179299;
+  --color-prettylights-syntax-invalid-illegal-bg: rgba(210, 15, 57, 0.15);
+  --color-prettylights-syntax-markup-heading: #d20f39;
   --color-prettylights-syntax-markup-italic: #df8e1d;
   --color-prettylights-syntax-markup-bold: #df8e1d;
   --color-prettylights-syntax-markup-deleted-text: #4c4f69;
-  --color-prettylights-syntax-markup-deleted-bg: rgb(210 15 57 / 40%);
+  --color-prettylights-syntax-markup-deleted-bg: rgba(210, 15, 57, 0.4);
   --color-prettylights-syntax-markup-inserted-text: #4c4f69;
-  --color-prettylights-syntax-markup-inserted-bg: rgb(64 160 43 / 40%);
+  --color-prettylights-syntax-markup-inserted-bg: rgba(64, 160, 43, 0.4);
   --color-prettylights-syntax-markup-changed-text: #4c4f69;
-  --color-prettylights-syntax-markup-changed-bg: rgb(223 142 29 / 40%);
+  --color-prettylights-syntax-markup-changed-bg: rgba(223, 142, 29, 0.4);
   --color-prettylights-syntax-markup-ignored-text: #4c4f69;
   --color-btn-text: #4c4f69;
   --color-btn-bg: #ccd0da;
@@ -40,7 +41,7 @@ main {
   --color-btn-primary-selected-bg: #50c836;
   --color-btn-primary-selected-shadow: 0 0 transparent;
   --color-btn-primary-disabled-text: #dce0e8;
-  --color-btn-primary-disabled-bg: rgb(64 160 43 / 40%);
+  --color-btn-primary-disabled-bg: rgba(64, 160, 43, 0.4);
   --color-btn-primary-disabled-border: transparent;
   --color-action-list-item-default-hover-bg: #bcc0cc;
   --color-segmented-control-bg: #acb0be;
@@ -55,29 +56,27 @@ main {
   --color-canvas-subtle: #e6e9ef;
   --color-border-default: #bcc0cc;
   --color-border-muted: #ccd0da;
-  --color-neutral-muted: rgb(156 160 176 / 20%);
-  --color-accent-fg: hsl(266deg 85% 55%);
+  --color-neutral-muted: rgba(156, 160, 176, 0.2);
+  --color-accent-fg: #8839ef;
   --color-accent-emphasis: #8839ef;
-  --color-accent-muted: rgb(136 57 239 / 40%);
-  --color-accent-subtle: rgb(136 57 239 / 15%);
+  --color-accent-muted: rgba(136, 57, 239, 0.4);
+  --color-accent-subtle: rgba(136, 57, 239, 0.15);
   --color-success-fg: #40a02b;
   --color-attention-fg: #fe640b;
   --color-attention-muted: #8839ef;
-  --color-attention-subtle: rgb(136 57 239 / 15%);
+  --color-attention-subtle: rgba(136, 57, 239, 0.15);
   --color-danger-fg: #d20f39;
-  --color-danger-muted: rgb(210 15 57 / 40%);
-  --color-danger-subtle: rgb(210 15 57 / 20%);
+  --color-danger-muted: rgba(210, 15, 57, 0.4);
+  --color-danger-subtle: rgba(210, 15, 57, 0.2);
   --color-primer-shadow-inset: 0 0 transparent;
   --color-scale-gray-7: #bcc0cc;
   --color-scale-blue-8: #0a4ed6;
   --color-social-reaction-bg-hover: var(--color-scale-gray-7);
   --color-social-reaction-bg-reacted-hover: var(--color-scale-blue-8);
 }
-
 main .gsc-comment-box-textarea::placeholder {
   color: #6c6f85;
 }
-
 main .gsc-loading-image {
   background-image: url("https://giscus.catppuccin.com/assets/loading.gif");
 }

--- a/styles/themes/catppuccin_macchiato.css
+++ b/styles/themes/catppuccin_macchiato.css
@@ -1,23 +1,24 @@
 main {
-  --color-prettylights-syntax-comment: #8087a2;
+  --color-prettylights-syntax-comment: #939ab7;
   --color-prettylights-syntax-constant: #8aadf4;
+  --color-prettylights-syntax-constant-other-reference-link: #8aadf4;
   --color-prettylights-syntax-entity: #8aadf4;
   --color-prettylights-syntax-storage-modifier-import: #f5a97f;
-  --color-prettylights-syntax-entity-tag: #8bd5ca;
-  --color-prettylights-syntax-keyword: #f5bde6;
+  --color-prettylights-syntax-entity-tag: #8aadf4;
+  --color-prettylights-syntax-keyword: #c6a0f6;
   --color-prettylights-syntax-string: #a6da95;
   --color-prettylights-syntax-variable: #f5a97f;
   --color-prettylights-syntax-invalid-illegal-text: #ed8796;
-  --color-prettylights-syntax-invalid-illegal-bg: rgb(237 135 150 / 15%);
-  --color-prettylights-syntax-markup-heading: #8bd5ca;
+  --color-prettylights-syntax-invalid-illegal-bg: rgba(237, 135, 150, 0.15);
+  --color-prettylights-syntax-markup-heading: #ed8796;
   --color-prettylights-syntax-markup-italic: #eed49f;
   --color-prettylights-syntax-markup-bold: #eed49f;
   --color-prettylights-syntax-markup-deleted-text: #cad3f5;
-  --color-prettylights-syntax-markup-deleted-bg: rgb(237 135 150 / 40%);
+  --color-prettylights-syntax-markup-deleted-bg: rgba(237, 135, 150, 0.4);
   --color-prettylights-syntax-markup-inserted-text: #cad3f5;
-  --color-prettylights-syntax-markup-inserted-bg: rgb(166 218 149 / 40%);
+  --color-prettylights-syntax-markup-inserted-bg: rgba(166, 218, 149, 0.4);
   --color-prettylights-syntax-markup-changed-text: #cad3f5;
-  --color-prettylights-syntax-markup-changed-bg: rgb(238 212 159 / 40%);
+  --color-prettylights-syntax-markup-changed-bg: rgba(238, 212, 159, 0.4);
   --color-prettylights-syntax-markup-ignored-text: #cad3f5;
   --color-btn-text: #cad3f5;
   --color-btn-bg: #363a4f;
@@ -40,7 +41,7 @@ main {
   --color-btn-primary-selected-bg: #c6e7bb;
   --color-btn-primary-selected-shadow: 0 0 transparent;
   --color-btn-primary-disabled-text: #181926;
-  --color-btn-primary-disabled-bg: rgb(166 218 149 / 40%);
+  --color-btn-primary-disabled-bg: rgba(166, 218, 149, 0.4);
   --color-btn-primary-disabled-border: transparent;
   --color-action-list-item-default-hover-bg: #494d64;
   --color-segmented-control-bg: #5b6078;
@@ -55,29 +56,27 @@ main {
   --color-canvas-subtle: #1e2030;
   --color-border-default: #494d64;
   --color-border-muted: #363a4f;
-  --color-neutral-muted: rgb(110 115 141 / 30%);
+  --color-neutral-muted: rgba(110, 115, 141, 0.2);
   --color-accent-fg: #c6a0f6;
   --color-accent-emphasis: #c6a0f6;
-  --color-accent-muted: rgb(198 160 246 / 40%);
-  --color-accent-subtle: rgb(198 160 246 / 15%);
+  --color-accent-muted: rgba(198, 160, 246, 0.4);
+  --color-accent-subtle: rgba(198, 160, 246, 0.15);
   --color-success-fg: #a6da95;
   --color-attention-fg: #f5a97f;
   --color-attention-muted: #c6a0f6;
-  --color-attention-subtle: rgb(198 160 246 / 15%);
+  --color-attention-subtle: rgba(198, 160, 246, 0.15);
   --color-danger-fg: #ed8796;
-  --color-danger-muted: rgb(237 135 150 / 40%);
-  --color-danger-subtle: rgb(237 135 150 / 20%);
+  --color-danger-muted: rgba(237, 135, 150, 0.4);
+  --color-danger-subtle: rgba(237, 135, 150, 0.2);
   --color-primer-shadow-inset: 0 0 transparent;
   --color-scale-gray-7: #494d64;
   --color-scale-blue-8: #5b8cf0;
   --color-social-reaction-bg-hover: var(--color-scale-gray-7);
   --color-social-reaction-bg-reacted-hover: var(--color-scale-blue-8);
 }
-
 main .gsc-comment-box-textarea::placeholder {
   color: #a5adcb;
 }
-
 main .gsc-loading-image {
   background-image: url("https://giscus.catppuccin.com/assets/loading.gif");
 }

--- a/styles/themes/catppuccin_mocha.css
+++ b/styles/themes/catppuccin_mocha.css
@@ -1,23 +1,24 @@
 main {
-  --color-prettylights-syntax-comment: #7f849c;
+  --color-prettylights-syntax-comment: #9399b2;
   --color-prettylights-syntax-constant: #89b4fa;
+  --color-prettylights-syntax-constant-other-reference-link: #89b4fa;
   --color-prettylights-syntax-entity: #89b4fa;
   --color-prettylights-syntax-storage-modifier-import: #fab387;
-  --color-prettylights-syntax-entity-tag: #94e2d5;
-  --color-prettylights-syntax-keyword: #f5c2e7;
+  --color-prettylights-syntax-entity-tag: #89b4fa;
+  --color-prettylights-syntax-keyword: #cba6f7;
   --color-prettylights-syntax-string: #a6e3a1;
   --color-prettylights-syntax-variable: #fab387;
   --color-prettylights-syntax-invalid-illegal-text: #f38ba8;
-  --color-prettylights-syntax-invalid-illegal-bg: rgb(243 139 168 / 15%);
-  --color-prettylights-syntax-markup-heading: #94e2d5;
+  --color-prettylights-syntax-invalid-illegal-bg: rgba(243, 139, 168, 0.15);
+  --color-prettylights-syntax-markup-heading: #f38ba8;
   --color-prettylights-syntax-markup-italic: #f9e2af;
   --color-prettylights-syntax-markup-bold: #f9e2af;
   --color-prettylights-syntax-markup-deleted-text: #cdd6f4;
-  --color-prettylights-syntax-markup-deleted-bg: rgb(243 139 168 / 40%);
+  --color-prettylights-syntax-markup-deleted-bg: rgba(243, 139, 168, 0.4);
   --color-prettylights-syntax-markup-inserted-text: #cdd6f4;
-  --color-prettylights-syntax-markup-inserted-bg: rgb(166 227 161 / 40%);
+  --color-prettylights-syntax-markup-inserted-bg: rgba(166, 227, 161, 0.4);
   --color-prettylights-syntax-markup-changed-text: #cdd6f4;
-  --color-prettylights-syntax-markup-changed-bg: rgb(249 226 175 / 40%);
+  --color-prettylights-syntax-markup-changed-bg: rgba(249, 226, 175, 0.4);
   --color-prettylights-syntax-markup-ignored-text: #cdd6f4;
   --color-btn-text: #cdd6f4;
   --color-btn-bg: #313244;
@@ -40,7 +41,7 @@ main {
   --color-btn-primary-selected-bg: #cbefc8;
   --color-btn-primary-selected-shadow: 0 0 transparent;
   --color-btn-primary-disabled-text: #11111b;
-  --color-btn-primary-disabled-bg: rgb(166 227 161 / 40%);
+  --color-btn-primary-disabled-bg: rgba(166, 227, 161, 0.4);
   --color-btn-primary-disabled-border: transparent;
   --color-action-list-item-default-hover-bg: #45475a;
   --color-segmented-control-bg: #585b70;
@@ -55,29 +56,27 @@ main {
   --color-canvas-subtle: #181825;
   --color-border-default: #45475a;
   --color-border-muted: #313244;
-  --color-neutral-muted: rgb(108 112 134 / 40%);
+  --color-neutral-muted: rgba(108, 112, 134, 0.2);
   --color-accent-fg: #cba6f7;
   --color-accent-emphasis: #cba6f7;
-  --color-accent-muted: rgb(203 166 247 / 40%);
-  --color-accent-subtle: rgb(203 166 247 / 15%);
+  --color-accent-muted: rgba(203, 166, 247, 0.4);
+  --color-accent-subtle: rgba(203, 166, 247, 0.15);
   --color-success-fg: #a6e3a1;
   --color-attention-fg: #fab387;
   --color-attention-muted: #cba6f7;
-  --color-attention-subtle: rgb(203 166 247 / 15%);
+  --color-attention-subtle: rgba(203, 166, 247, 0.15);
   --color-danger-fg: #f38ba8;
-  --color-danger-muted: rgb(243 139 168 / 40%);
-  --color-danger-subtle: rgb(243 139 168 / 20%);
+  --color-danger-muted: rgba(243, 139, 168, 0.4);
+  --color-danger-subtle: rgba(243, 139, 168, 0.2);
   --color-primer-shadow-inset: 0 0 transparent;
   --color-scale-gray-7: #45475a;
   --color-scale-blue-8: #5895f8;
   --color-social-reaction-bg-hover: var(--color-scale-gray-7);
   --color-social-reaction-bg-reacted-hover: var(--color-scale-blue-8);
 }
-
 main .gsc-comment-box-textarea::placeholder {
   color: #a6adc8;
 }
-
 main .gsc-loading-image {
   background-image: url("https://giscus.catppuccin.com/assets/loading.gif");
 }


### PR DESCRIPTION
As mentioned at https://github.com/giscus/giscus/pull/1411#issuecomment-2566670490, preferabbly we can update the themes at the upstream Catppuccin theme repository first. I copied over your suggested changes, and this update also includes some other changes for syntax highlighting.