### PR TITLE
fix: correct invalid CSS selectors in markdown and clipboard styles

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -428,7 +428,7 @@ details summary {
 
 .ClipboardButton:focus,
 .snippet-clipboard-content:hover .ClipboardButton,
-.highlight:hover .ClipboardButton, {
+.highlight:hover .ClipboardButton {
   @apply opacity-100;
 
   animation: fade-in 0.2s both;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -79,7 +79,7 @@ a:hover {
 }
 
 .markdown pre,
-.markdown .highlight pre, {
+.markdown .highlight pre {
   @apply p-4 overflow-auto text-xs rounded-md;
 
   line-height: 1.45;


### PR DESCRIPTION
## Summary

This PR fixes invalid trailing commas in two CSS selector blocks within the Markdown and clipboard button styles. While these issues did not affect rendering in development, they could cause build failures or `@apply` errors in stricter environments.

---

## Changes

### 1. Markdown code block selector

**Before:**

```css
.markdown .highlight pre, {
  @apply p-4 overflow-auto text-xs rounded-md;
}
```

**After:**

```css
.markdown .highlight pre {
  @apply p-4 overflow-auto text-xs rounded-md;
}
```

### 2. Clipboard button selector

**Before:**

```css
.highlight:hover .ClipboardButton, {
  @apply opacity-100;
}
```

**After:**

```css
.highlight:hover .ClipboardButton {
  @apply opacity-100;
}
```

---

Fixing them ensures consistent, valid CSS syntax and prevents future issues.

---

## Notes

This is a syntax-only fix. There are no visual or behavioral changes.