### PR TITLE
fix: update emoji extraction logic to support new GitHub HTML format

### DIFF
--- a/pages/api/discussions/categories.ts
+++ b/pages/api/discussions/categories.ts
@@ -47,7 +47,7 @@ export default async function DiscussionCategoriesApi(
     discussionCategories: { nodes },
   } = repository;
   const categories = nodes.map(({ emojiHTML, ...rest }) => ({
-    emoji: emojiHTML?.match(/">(.*?)<\/g-emoji/)?.[1] || '',
+    emoji: emojiHTML?.match(/^<div>([^<]+)<\/div>$/)?.[1] || '',
     ...rest,
   }));
 


### PR DESCRIPTION
GitHub's rendered emoji HTML has changed. Previously, we extracted emojis using:

```javascript
/> (.*?) <\/g-emoji/
```

This matched the format likes:

- Native emoji: `<p><g-emoji alias="speech_balloon" ...>💬</g-emoji>...</p>`
- Custom emoji: `<p><img />...</p> ` (ignored by design)

However, I discovered that GitHub now returns emojis in two new formats:

- Native emoji: `<div>💬</div>`
- Custom emoji: `<div><img alt=":octocat:" ... /></div>`

As a result, the previous extraction logic no longer works.

<p align="center">
<img src="https://github.com/user-attachments/assets/9987e7cf-9c95-44e1-87cb-6606b4ce94c6" width="30%" />
</p>

https://github.com/giscus/giscus/blob/d90866dfb460308e7ed745b3b040657622845f82/components/Configuration.tsx#L389-L391

To address this issue, this pull request updates the extraction logic to:

```javascript
/^<div>([^<]+)<\/div>$/
```

Example result:

```sh
> "<div>💬</div>"?.match(/^<div>([^<]+)<\/div>$/)?.[1] || ''
'💬'
> '<div><img class="emoji" title=":octocat:" alt=":octocat:" src="https://github.githubassets.com/images/icons/emoji/octocat.png" height="20" width="20" align="absmiddle"></div>'?.match(/^<div>([^<]+)<\/div>$/)?.[1] || ''
''
```
This ensures compatibility with GitHub's current emoji rendering format.

Custom emojis (e.g., `<img alt=":octocat:" ... />`) are intentionally not matched, in line with #122.