### PR TITLE
fix: progressive-disclosure-line URLs now use githubassets.com

### DIFF
--- a/styles/themes/cobalt.css
+++ b/styles/themes/cobalt.css
@@ -88,7 +88,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/custom_example.css
+++ b/styles/themes/custom_example.css
@@ -92,7 +92,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 /*! Custom CSS */

--- a/styles/themes/dark.css
+++ b/styles/themes/dark.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/dark_dimmed.css
+++ b/styles/themes/dark_dimmed.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/dark_high_contrast.css
+++ b/styles/themes/dark_high_contrast.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/dark_protanopia.css
+++ b/styles/themes/dark_protanopia.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/dark_tritanopia.css
+++ b/styles/themes/dark_tritanopia.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/gruvbox.css
+++ b/styles/themes/gruvbox.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line.svg");
 }
 
 main .gsc-loading-image {
@@ -187,7 +187,7 @@ main .gsc-loading-image {
     }
 
     main .pagination-loader-container {
-    background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+    background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
     }
 
     main .gsc-loading-image {

--- a/styles/themes/gruvbox_dark.css
+++ b/styles/themes/gruvbox_dark.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/gruvbox_light.css
+++ b/styles/themes/gruvbox_light.css
@@ -96,7 +96,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/light.css
+++ b/styles/themes/light.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/light_high_contrast.css
+++ b/styles/themes/light_high_contrast.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/light_protanopia.css
+++ b/styles/themes/light_protanopia.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/light_tritanopia.css
+++ b/styles/themes/light_tritanopia.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/noborder_dark.css
+++ b/styles/themes/noborder_dark.css
@@ -88,7 +88,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/noborder_gray.css
+++ b/styles/themes/noborder_gray.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/noborder_light.css
+++ b/styles/themes/noborder_light.css
@@ -88,7 +88,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/preferred_color_scheme.css
+++ b/styles/themes/preferred_color_scheme.css
@@ -91,7 +91,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line.svg");
 }
 
 main .gsc-loading-image {
@@ -193,7 +193,7 @@ main .gsc-loading-image {
   }
 
   main .pagination-loader-container {
-    background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+    background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
   }
 
   main .gsc-loading-image {

--- a/styles/themes/purple_dark.css
+++ b/styles/themes/purple_dark.css
@@ -88,7 +88,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 main .gsc-loading-image {

--- a/styles/themes/transparent_dark.css
+++ b/styles/themes/transparent_dark.css
@@ -93,7 +93,7 @@ main {
 }
 
 main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+  background-image: url("https://github.githubassets.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
 }
 
 .gsc-pagination-button {


### PR DESCRIPTION
Themes under styles/themes/ reference the progressive-disclosure-line SVG using https://github.com/images/modules/pulls/.... That path no longer resolves on github.com (returns 404), so main .pagination-loader-container shows a missing icon.

GitHub serves these assets from github.githubassets.com now. Swapping github.com/images/ for github.githubassets.com/images/ restores the icon.