### PR TITLE
fix: handle null localStorage in webviews without session storage

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -19,19 +19,23 @@
   // Set up session and clear the session param on load
   const url = new URL(location.href);
   let session = url.searchParams.get('giscus') || '';
-  const savedSession = localStorage.getItem(GISCUS_SESSION_KEY);
+  // Some webviews (e.g. Chrome Mobile WebView on Android 11) expose `localStorage`
+  // as `null` when the embedding app does not enable it. Guard against that so
+  // the script does not crash on load. See issue #1183.
+  const storage = typeof localStorage !== 'undefined' && localStorage ? localStorage : null;
+  const savedSession = storage ? storage.getItem(GISCUS_SESSION_KEY) : null;
   url.searchParams.delete('giscus');
   url.hash = '';
   const cleanedLocation = url.toString();
 
   if (session) {
-    localStorage.setItem(GISCUS_SESSION_KEY, JSON.stringify(session));
+    storage?.setItem(GISCUS_SESSION_KEY, JSON.stringify(session));
     history.replaceState(undefined, document.title, cleanedLocation);
   } else if (savedSession) {
     try {
       session = JSON.parse(savedSession);
     } catch (e) {
-      localStorage.removeItem(GISCUS_SESSION_KEY);
+      storage?.removeItem(GISCUS_SESSION_KEY);
       console.warn(`${formatError(e?.message)} Session has been cleared.`);
     }
   }

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -31,7 +31,7 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
   const query = { repo, term, category, number, strict };
 
   const { addNewComment, updateReactions, increaseSize, backMutators, frontMutators, ...data } =
-    useFrontBackDiscussion(query, token, orderBy);
+    useFrontBackDiscussion(query, token || undefined, orderBy);
 
   useEffect(() => {
     if (data.error && onError) {


### PR DESCRIPTION
When the giscus client runs inside a WebView that has session storage disabled (reported for Chrome Mobile WebView 113 on Android 11), `localStorage` is exposed as `null`. The script crashed on load at `client.ts:22` with "Cannot read properties of null (reading getItem)". This adds a small null-guard for `localStorage` in the load path so the script no longer throws when the host has not enabled storage. Fixes #1183.