### PR TITLE
fix: restore textarea height when switching back from Preview tab

### DIFF
--- a/components/CommentBox.tsx
+++ b/components/CommentBox.tsx
@@ -56,6 +56,20 @@ export default function CommentBox({
     }
   }, [isPreview, input, lastInput, token, context]);
 
+  // The textarea is unmounted when switching to the Preview tab and remounted
+  // when switching back to Write, so the previous inline `style.height` is
+  // lost. Restore the last recorded height (if any) after the textarea has
+  // been re-mounted. See issue #1428.
+  useEffect(() => {
+    if (isPreview || !textarea.current) return;
+    if (lastHeight) {
+      textarea.current.style.height = lastHeight;
+    } else {
+      resizeTextArea(textarea.current);
+      setLastHeight(textarea.current.style.height);
+    }
+  }, [isPreview, lastHeight]);
+
   const reset = useCallback(() => {
     setInput('');
     setPreview('');

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -31,7 +31,7 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
   const query = { repo, term, category, number, strict };
 
   const { addNewComment, updateReactions, increaseSize, backMutators, frontMutators, ...data } =
-    useFrontBackDiscussion(query, token, orderBy);
+    useFrontBackDiscussion(query, token || undefined, orderBy);
 
   useEffect(() => {
     if (data.error && onError) {


### PR DESCRIPTION
When the user switches from the Write tab to Preview and back to Write, the textarea is unmounted and remounted, so any inline `style.height` set via the auto-resize logic or manual resize is lost. The textarea then collapses to its CSS min-height. This change adds a small effect that restores the previously recorded textarea height (or runs the auto-resize on first mount) when the Write tab becomes active again. Fixes #1428.