### PR TITLE
fix: guard localStorage reads when running in disabled-storage WebViews

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -7,6 +7,16 @@
     return `[giscus] An error occurred. Error message: "${message}".`;
   }
 
+  // Some embedded WebViews disable localStorage entirely; reading from it
+  // throws. Treat any failure to read as "no saved session" instead of crashing.
+  function safeSessionRead() {
+    try {
+      return localStorage.getItem(GISCUS_SESSION_KEY);
+    } catch {
+      return null;
+    }
+  }
+
   function getMetaContent(property: string, og = false) {
     const ogSelector = og ? `meta[property='og:${property}'],` : '';
     const element = document.querySelector<HTMLMetaElement>(
@@ -19,7 +29,7 @@
   // Set up session and clear the session param on load
   const url = new URL(location.href);
   let session = url.searchParams.get('giscus') || '';
-  const savedSession = localStorage.getItem(GISCUS_SESSION_KEY);
+  const savedSession = safeSessionRead();
   url.searchParams.delete('giscus');
   url.hash = '';
   const cleanedLocation = url.toString();
@@ -165,7 +175,7 @@
       message.includes('State has expired')
     ) {
       // Might be because token is expired or other causes
-      if (localStorage.getItem(GISCUS_SESSION_KEY) !== null) {
+      if (safeSessionRead() !== null) {
         localStorage.removeItem(GISCUS_SESSION_KEY);
         console.warn(`${formatError(message)} Session has been cleared.`);
         signOut();

--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -31,7 +31,7 @@ export default function Giscus({ onDiscussionCreateRequest, onError }: IGiscusPr
   const query = { repo, term, category, number, strict };
 
   const { addNewComment, updateReactions, increaseSize, backMutators, frontMutators, ...data } =
-    useFrontBackDiscussion(query, token, orderBy);
+    useFrontBackDiscussion(query, token || undefined, orderBy);
 
   useEffect(() => {
     if (data.error && onError) {


### PR DESCRIPTION
Some embedded WebViews (e.g. Chrome Mobile WebView 113 on Android 11 in apps that do not enable storage) make `localStorage.getItem` throw instead of returning null. That crashes the widget on load with `Cannot read properties of null (reading 'getItem')` (see #1183).

This wraps the two `localStorage.getItem` call sites in a small `safeSessionRead` helper that catches the throw and returns null. `localStorage.setItem` / `removeItem` are not modified, since they only run when we already have a valid read and are unreachable from the reported crash path.