### PR TITLE
fix(oauth): validate aesGcmDecrypt input and surface typed errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ yarn-error.log*
 # Compiled client script
 public/client.js
 
+# Compiled test artefacts (see tsconfig.test.json)
+/.test-build/
+
 # Compiled themes
 public/themes/
 

--- a/lib/oauth/encryption.test.ts
+++ b/lib/oauth/encryption.test.ts
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { aesGcmDecrypt, aesGcmEncrypt, DecryptionError } from './encryption';
+
+// The validation in `aesGcmDecrypt` runs before any webcrypto call, so these
+// tests do not require a working `webcrypto` import. They exercise the input
+// shape checks that protect callers from uncaught `TypeError`s when a stored
+// state value is missing, truncated, or otherwise malformed.
+//
+// `aesGcmDecrypt` is declared `async`, so the input-validation throws are
+// surfaced as a rejected promise. The assertions below therefore use
+// `assert.rejects` (with `await`) rather than `assert.throws`.
+
+test('aesGcmDecrypt rejects with DecryptionError on empty string', async () => {
+  await assert.rejects(
+    () => aesGcmDecrypt('', 'password'),
+    (err: unknown) => err instanceof DecryptionError && /ciphertext/i.test((err as Error).message),
+  );
+});
+
+test('aesGcmDecrypt rejects with DecryptionError on short input (less than 24 chars)', async () => {
+  await assert.rejects(() => aesGcmDecrypt('abcdef', 'password'), DecryptionError);
+  await assert.rejects(() => aesGcmDecrypt('a'.repeat(23), 'password'), DecryptionError);
+});
+
+test('aesGcmDecrypt rejects with DecryptionError on non-string input', async () => {
+  // Cast through `unknown` so the test compiles; the function should still
+  // throw a typed error and never reach the `webcrypto` call.
+  await assert.rejects(() => aesGcmDecrypt(null as unknown as string, 'password'), DecryptionError);
+  await assert.rejects(
+    () => aesGcmDecrypt(undefined as unknown as string, 'password'),
+    DecryptionError,
+  );
+  await assert.rejects(() => aesGcmDecrypt(42 as unknown as string, 'password'), DecryptionError);
+  await assert.rejects(() => aesGcmDecrypt({} as unknown as string, 'password'), DecryptionError);
+});
+
+test('aesGcmDecrypt rejects with DecryptionError on whitespace-only input', async () => {
+  await assert.rejects(() => aesGcmDecrypt('   ', 'password'), DecryptionError);
+});
+
+test('aesGcmDecrypt rejects when the IV segment contains non-hex characters', async () => {
+  // 24 chars long, but the second byte is 'zz' which is not valid hex.
+  const bad = '00zz' + 'A'.repeat(20);
+  await assert.rejects(
+    () => aesGcmDecrypt(bad, 'password'),
+    (err: unknown) => {
+      if (!(err instanceof DecryptionError)) return false;
+      return /hex|iv|invalid/i.test((err as Error).message);
+    },
+  );
+});
+
+test('DecryptionError is a subclass of Error and carries a stable name', () => {
+  const err = new DecryptionError('boom');
+  assert.ok(err instanceof Error);
+  assert.ok(err instanceof DecryptionError);
+  assert.equal(err.name, 'DecryptionError');
+  assert.equal(err.message, 'boom');
+});
+
+test('DecryptionError.cause is forwarded to the underlying Error', () => {
+  const cause = new Error('inner');
+  const err = new DecryptionError('outer', { cause });
+  assert.strictEqual((err as Error & { cause?: unknown }).cause, cause);
+});
+
+test('DecryptionError preserves the original message even without a cause', () => {
+  const err = new DecryptionError('ciphertext is empty');
+  assert.equal(err.message, 'ciphertext is empty');
+  assert.equal((err as Error & { cause?: unknown }).cause, undefined);
+});
+
+test('aesGcmDecrypt rejects when the IV segment has odd-length hex', async () => {
+  // 24 chars but the slice yields an odd grouping because of an embedded
+  // space at position 1 ("0 0...").
+  const odd = '0 0' + '0'.repeat(21);
+  await assert.rejects(() => aesGcmDecrypt(odd, 'password'), DecryptionError);
+});
+
+test('exported types are reachable from the module entry', () => {
+  // Smoke-test that the module exports the right shapes. Runtime-only assertion.
+  assert.equal(typeof aesGcmDecrypt, 'function');
+  assert.equal(typeof aesGcmEncrypt, 'function');
+  assert.equal(typeof DecryptionError, 'function');
+});

--- a/lib/oauth/encryption.ts
+++ b/lib/oauth/encryption.ts
@@ -1,6 +1,56 @@
 import { webcrypto } from '../utils';
 
 /**
+ * Error thrown when input to {@link aesGcmDecrypt} cannot be processed
+ * (wrong type, wrong length, malformed IV hex, etc.). Exposed as a distinct
+ * subclass so callers can branch on it without `instanceof` checking the
+ * full `Error` hierarchy.
+ */
+export class DecryptionError extends Error {
+  override readonly name = 'DecryptionError';
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    if (options && 'cause' in options) {
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+const IV_HEX_LENGTH = 24; // 12 bytes × 2 hex chars
+
+function isValidHex(s: string): boolean {
+  return /^[0-9a-fA-F]+$/.test(s) && s.length % 2 === 0;
+}
+
+function parseHexBytes(hex: string, label: string): Uint8Array {
+  if (!isValidHex(hex)) {
+    throw new DecryptionError(`Invalid ${label}: expected an even-length hex string.`);
+  }
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    const parsed = parseInt(hex.substring(i, i + 2), 16);
+    if (Number.isNaN(parsed)) {
+      throw new DecryptionError(`Invalid ${label}: byte at position ${i / 2} is not hex.`);
+    }
+    bytes[i / 2] = parsed;
+  }
+  return bytes;
+}
+
+function decodeBase64ToBytes(b64: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(b64, 'base64'));
+  }
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}
+
+/**
  * Encrypts plaintext using AES-GCM with supplied password, for decryption with aesGcmDecrypt().
  *                                                                      (c) Chris Veness MIT Licence
  *
@@ -38,6 +88,10 @@ export async function aesGcmEncrypt(plaintext: string, password: string): Promis
 
 /**
  * Decrypts ciphertext encrypted with aesGcmEncrypt() using supplied password.
+ * Throws a {@link DecryptionError} when the ciphertext is the wrong type,
+ * too short, or contains a malformed IV. `aesGcmDecrypt` is the only entry
+ * point that touches `webcrypto.subtle.decrypt`, so any pre-conditions can
+ * be checked synchronously and surface as a typed error to the caller.
  *                                                                      (c) Chris Veness MIT Licence
  *
  * @param   {String} ciphertext - Ciphertext to be decrypted.
@@ -49,23 +103,40 @@ export async function aesGcmEncrypt(plaintext: string, password: string): Promis
  *   aesGcmDecrypt(ciphertext, 'pw').then(function(plaintext) { console.log(plaintext); });
  */
 export async function aesGcmDecrypt(ciphertext: string, password: string): Promise<string> {
+  if (typeof ciphertext !== 'string') {
+    throw new DecryptionError(
+      `Invalid ciphertext: expected a string, received ${ciphertext === null ? 'null' : typeof ciphertext}.`,
+    );
+  }
+  if (ciphertext.length < IV_HEX_LENGTH) {
+    throw new DecryptionError(
+      `Invalid ciphertext: expected at least ${IV_HEX_LENGTH} hex characters, received ${ciphertext.length}.`,
+    );
+  }
+
   const pwUtf8 = new TextEncoder().encode(password); // encode password as UTF-8
   const pwHash = await webcrypto.subtle.digest('SHA-256', pwUtf8); // hash the password
 
-  const iv = ciphertext
-    .slice(0, 24)
-    .match(/.{2}/g)
-    .map((byte) => parseInt(byte, 16)); // get iv from ciphertext
-
-  const alg = { name: 'AES-GCM', iv: new Uint8Array(iv) }; // specify algorithm to use
+  const ivHex = ciphertext.slice(0, IV_HEX_LENGTH);
+  let iv: Uint8Array;
+  try {
+    iv = parseHexBytes(ivHex, 'IV');
+  } catch (e) {
+    if (e instanceof DecryptionError) throw e;
+    throw new DecryptionError('Invalid IV: failed to parse hex bytes.', { cause: e });
+  }
+  const alg = { name: 'AES-GCM', iv }; // specify algorithm to use
 
   const key = await webcrypto.subtle.importKey('raw', pwHash, alg, false, ['decrypt']); // use pw to generate key
 
-  const ctStr = Buffer.from(ciphertext.slice(24), 'base64').toString('binary'); // decode base64 ciphertext
-  const ctUint8 = new Uint8Array(ctStr.match(/[\s\S]/g).map((ch) => ch.charCodeAt(0))); // ciphertext as Uint8Array
-  // note: why doesn't ctUint8 = new TextEncoder().encode(ctStr) work?
-
-  const plainBuffer = await webcrypto.subtle.decrypt(alg, key, ctUint8); // decrypt ciphertext using key
+  const ctBytes = decodeBase64ToBytes(ciphertext.slice(IV_HEX_LENGTH));
+  let plainBuffer: ArrayBuffer;
+  try {
+    plainBuffer = await webcrypto.subtle.decrypt(alg, key, ctBytes); // decrypt ciphertext using key
+  } catch (e) {
+    // AES-GCM failure (wrong key, tampered ciphertext, truncated tag, etc.).
+    throw new DecryptionError('Failed to decrypt ciphertext.', { cause: e });
+  }
   const plaintext = new TextDecoder().decode(plainBuffer); // decode password from UTF-8
 
   return plaintext; // return the plaintext

--- a/lib/oauth/state.ts
+++ b/lib/oauth/state.ts
@@ -1,4 +1,4 @@
-import { aesGcmEncrypt, aesGcmDecrypt } from './encryption';
+import { aesGcmEncrypt, aesGcmDecrypt, DecryptionError } from './encryption';
 
 const DEFAULT_VALIDITY_PERIOD = 5 * 60 * 1000; // 5 minutes
 
@@ -21,11 +21,15 @@ export async function decodeState(encryptedState: string, password: string) {
   try {
     const decrypted = await aesGcmDecrypt(encryptedState, password);
     state = JSON.parse(decrypted);
-  } catch {
-    throw new Error('Invalid state value.');
+  } catch (e) {
+    // `aesGcmDecrypt` throws `DecryptionError` for malformed input. `JSON.parse`
+    // throws `SyntaxError` for an unparsable envelope. Both are surfaced as
+    // "Invalid state value" so the OAuth flow has a single, well-defined
+    // failure mode to handle.
+    throw new DecryptionError('Invalid state value.', { cause: e });
   }
   if (Date.now() > state.expires) {
-    throw new Error('State has expired.');
+    throw new DecryptionError('State has expired.');
   }
   return state.value;
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint": "stylelint styles/**/*.css && eslint . --cache --max-warnings 0",
     "lint:fix": "stylelint --fix styles/**/*.css && eslint --fix . --cache --max-warnings 0",
     "format": "prettier --check .",
-    "format:fix": "prettier --write ."
+    "format:fix": "prettier --write .",
+    "test": "tsc -p tsconfig.test.json && node --test .test-build/lib/oauth/encryption.test.js"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^12.3.4",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "lib": ["dom", "esnext"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": ".test-build",
+    "rootDir": ".",
+    "declaration": false,
+    "sourceMap": false,
+    "noImplicitAny": false,
+    "resolveJsonModule": true
+  },
+  "include": ["lib/oauth/encryption.ts", "lib/oauth/encryption.test.ts"]
+}


### PR DESCRIPTION
## Summary
- `aesGcmDecrypt` in `lib/oauth/encryption.ts` assumed a 24-character IV prefix and parsed the hex via `.match(/.{2}/g).map(parseInt, 16)`. That throws a bare `TypeError` on empty, `null`, non-string, or short input, and on inputs whose IV segment is not valid hex. The throw was caught at the call site in `lib/oauth/state.ts` and surfaced as a generic `Error`, losing the distinction between malformed ciphertext and any other internal failure.
- This change introduces a `DecryptionError` class that the encryption layer always throws, validates the ciphertext type and length synchronously before any `webcrypto` call, replaces the regex/`.map` IV parser with a typed hex parser, and routes `webcrypto.subtle.decrypt` failures through the same error type. `lib/oauth/state.ts` now throws `DecryptionError` for both invalid and expired states, so the OAuth flow has a single, typed error class to branch on.

## Changes
- `lib/oauth/encryption.ts`:
  - New exported `DecryptionError` class (extends `Error`, fixed `name`, optional `cause`).
  - `aesGcmDecrypt` now rejects `null`, non-string, and inputs shorter than 24 characters with `DecryptionError` before touching `webcrypto`.
  - New `parseHexBytes` helper validates even-length hex and throws `DecryptionError` on the IV segment.
  - `webcrypto.subtle.decrypt` failures (wrong key, tampered ciphertext, truncated tag) are wrapped in `DecryptionError` with the original error as `cause`.
  - The body-decoding helper uses `Buffer.from(..., 'base64')` directly to avoid the previous `String.fromCharCode` round-trip.
- `lib/oauth/state.ts`: re-throws the inner failure as `DecryptionError('Invalid state value.', { cause })`; the expiry check now also throws `DecryptionError` so both failure modes share a class.
- `lib/oauth/encryption.test.ts` (new): 10 `node:test` cases covering empty / short / non-string / whitespace / non-hex / odd-length-hex input, plus the `DecryptionError` class shape.
- `tsconfig.test.json` (new): CJS build target for tests, `outDir: .test-build`.
- `package.json`: new `test` script: `tsc -p tsconfig.test.json && node --test .test-build/lib/oauth/encryption.test.js`.
- `.gitignore`: ignore `.test-build/`.

## Testing
- `yarn cscript` — `tsc client.ts --outDir public` clean.
- `yarn lint` — eslint + stylelint pass with `--max-warnings 0`.
- `yarn format` — prettier --check passes.
- `yarn test` — `tsc -p tsconfig.test.json` clean, `node --test` reports 10/10 passing.
  ```
  # tests 10
  # pass 10
  # fail 0
  ```

## Notes
- No new runtime dependencies. The test runner uses Node 18+ built-in `node:test`.
- No public API change. The only observable difference is the error class, which is a strict superset of the previous `Error` (`name` is `'DecryptionError'`, message is the same string for the existing two failure paths).
- The PR is a strict bug fix and a typed-error refactor. No behavior change for valid input.